### PR TITLE
Add option to suppress the linter

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -30,4 +30,4 @@ jobs:
       run: |-
         cp ginkgo-linter testdata/src/a
         cd testdata/src/a
-        [[ $(./ginkgo-linter . 2>&1 | wc -l) == 300 ]]
+        [[ $(./ginkgo-linter . 2>&1 | wc -l) == 301 ]]

--- a/README.md
+++ b/README.md
@@ -38,3 +38,32 @@ The output of the linter,when finding issues, looks like this:
 ./testdata/src/a/a.go:18:5: ginkgo-linter: wrong length check; consider using `Expect("").Should(BeEmpty())` instead
 ./testdata/src/a/a.go:22:5: ginkgo-linter: wrong length check; consider using `Expect("").Should(BeEmpty())` instead
 ```
+
+## Suppress the linter
+To suppress the wrong length check warning, add a comment with (only)
+`ginkgo-linter:supressLengthCheckWarning`. There are two options to use this comment:
+1. If the comment is at the top of the file, supress the warning for the whole file; e.g.:
+   ```go
+   package mypackage
+   
+   // ginkgo-linter:ignore-length-warning
+   
+   import (
+       . "github.com/onsi/ginkgo/v2"
+       . "github.com/onsi/gomega"
+   )
+   
+   var _ = Describe("my test", func() {
+        It("should do something", func() {
+            Expect(len("abc")).Should(Equal(3)) // nothing in this file will trigger the warning
+        })
+   })
+   ```
+2. If the comment is before a wrong length check expression, the warning is suppressed for this expression only; for example:
+   ```go
+   It("should test something", func() {
+       // ginkgo-linter:ignore-length-warning
+       Expect(len("abc")).Should(Equal(3)) // this line will not trigger the warning
+       Expect(len("abc")).Should(Equal(3)) // this line will trigger the warning
+   }
+   ```

--- a/ginkgo_linter_test.go
+++ b/ginkgo_linter_test.go
@@ -22,9 +22,11 @@ func TestGinkgoLinter(t *testing.T) {
 //}
 
 var _ = Describe("", func() {
-	It("Test all", func() {
-		testdata := analysistest.TestData()
+	Context("test a", func() {
+		It("Test all", func() {
+			testdata := analysistest.TestData()
 
-		analysistest.Run(GinkgoT(), testdata, Analyzer, "a")
+			analysistest.Run(GinkgoT(), testdata, Analyzer, "a")
+		})
 	})
 })

--- a/testdata/src/a/b.go
+++ b/testdata/src/a/b.go
@@ -1,0 +1,32 @@
+package a
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Supress wrong length check", func() {
+	Context("test ginkgo-linter:ignore-length-warning", func() {
+		It("should ignore length warning", func() {
+			// ginkgo-linter:ignore-length-warning
+			Expect(len("abc")).Should(Equal(3))
+			Expect(len("abc")).Should(Equal(3)) // want `ginkgo-linter: wrong length check; consider using .Expect\("abc"\)\.Should\(HaveLen\(3\)\). instead`
+			Expect("123").To(HaveLen(3))
+			/*
+
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+				aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+				Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+				occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+				ginkgo-linter:ignore-length-warning
+
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+				aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+				Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+				occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+			*/
+			Expect(len("abc")).Should(Equal(3))
+		})
+	})
+})

--- a/testdata/src/a/c.go
+++ b/testdata/src/a/c.go
@@ -1,0 +1,15 @@
+package a
+
+// ginkgo-linter:ignore-length-warning
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("suppress file", func() {
+	It("should ignore length warning", func() {
+		Expect(len("abc")).Should(Equal(3))
+		Expect(len("abc")).ShouldNot(BeZero())
+	})
+})

--- a/testdata/src/a/d.go
+++ b/testdata/src/a/d.go
@@ -1,0 +1,29 @@
+package a
+
+/*
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+ginkgo-linter:ignore-length-warning
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+*/
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("test data for the ginkgo-linter", func() {
+	Context("test ginkgo-linter:ignore-length-warning", func() {
+		It("should ignore length warning", func() {
+			Expect(len("abc")).Should(Equal(3))
+			Expect(len("abc")).Should(Equal(3))
+			Expect("123").To(HaveLen(3))
+		})
+	})
+})


### PR DESCRIPTION
It is now possible to suppress the wrong length check linter, iether for
a specific line, or for a whole file.