### PR TITLE
Remove all the dependencies in ginkgo & gomega

### DIFF
--- a/ginkgo_linter.go
+++ b/ginkgo_linter.go
@@ -35,7 +35,8 @@ For example:
 	Expect(len(x).Should(Equal(1))
 This should be replaced with:
 	Expect(x).Should(HavelLen(1)`,
-	Run: run,
+	Run:              run,
+	RunDespiteErrors: true,
 }
 
 const (


### PR DESCRIPTION
By setting the Analyzer's RunDespiteErrors field to true, the type
check is skiped and the linter can work without the need to actually
import ginkgo and gomega.

This will ease the integration with other applications, such as
golangci-lint.