### PR TITLE
Add nil check warning + command line flags

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -28,4 +28,7 @@ jobs:
       run: |-
         cp ginkgo-linter testdata/src/a
         cd testdata/src/a
-        [[ $(./ginkgo-linter . 2>&1 | wc -l) == 301 ]]
+        [[ $(./ginkgo-linter ./... 2>&1 | wc -l) == 1946 ]]
+        [[ $(./ginkgo-linter --suppress-len-assertion=true ./... 2>&1 | wc -l) == 1345 ]]
+        [[ $(./ginkgo-linter --suppress-nil-assertion=true ./... 2>&1 | wc -l) == 601 ]]
+        [[ $(./ginkgo-linter --suppress-nil-assertion=true --suppress-len-assertion=true ./... 2>&1 | wc -l) == 0 ]]

--- a/README.md
+++ b/README.md
@@ -11,24 +11,26 @@ ginkgo-linter [-fix] .
 Use the `-fix` flag to apply the fix suggestions to the source code.
 
 ## Linter Checks
-### Wrong Length checks
+The linter checks the `Expect`, `ExpectWithOffset` and the `Ω` "actual" functions, with the `Should`, `ShouldNot`, `To`, `ToNot` and `NotTo` assertion functions.
+
+It also supports the embedded `Not()` matcher
+
+### Wrong Length Assertion
 The linter finds assertion of the golang built-in `len` function, with all kind of matchers, while there are already gomega matchers for these usecases; We want to assert the item, rather than its length.
 
 There are several wrong patterns:
 ```go
-Expect(len(x)).To(Equal(0)) // should be Expect(x).To(BeEmpty())
-Expect(len(x)).To(BeZero()) // should be Expect(x).To(BeEmpty())
-Expect(len(x)).To(BeNumeric(">", 0)) // should be Expect(x).ToNot(BeEmpty())
-Expect(len(x)).To(BeNumeric(">=", 1)) // should be Expect(x).ToNot(BeEmpty())
-Expect(len(x)).To(BeNumeric("==", 0)) // should be Expect(x).To(BeEmpty())
-Expect(len(x)).To(BeNumeric("!=", 0)) // should be Expect(x).ToNot(BeEmpty())
+Expect(len(x)).To(Equal(0)) // should be: Expect(x).To(BeEmpty())
+Expect(len(x)).To(BeZero()) // should be: Expect(x).To(BeEmpty())
+Expect(len(x)).To(BeNumeric(">", 0)) // should be: Expect(x).ToNot(BeEmpty())
+Expect(len(x)).To(BeNumeric(">=", 1)) // should be: Expect(x).ToNot(BeEmpty())
+Expect(len(x)).To(BeNumeric("==", 0)) // should be: Expect(x).To(BeEmpty())
+Expect(len(x)).To(BeNumeric("!=", 0)) // should be: Expect(x).ToNot(BeEmpty())
 
-Expect(len(x)).To(Equal(1)) // should be Expect(x).To(HaveLen(1))
-Expect(len(x)).To(BeNumeric("==", 2)) // should be Expect(x).To(HaveLen(2))
-Expect(len(x)).To(BeNumeric("!=", 3)) // should be Expect(x).ToNot(HaveLen(3))
+Expect(len(x)).To(Equal(1)) // should be: Expect(x).To(HaveLen(1))
+Expect(len(x)).To(BeNumeric("==", 2)) // should be: Expect(x).To(HaveLen(2))
+Expect(len(x)).To(BeNumeric("!=", 3)) // should be: Expect(x).ToNot(HaveLen(3))
 ```
-
-The linter supports the `Expect`, `ExpectWithOffset` and the `Ω` "actual" functions, and the `Should`, `ShouldNot`, `To`, `ToNot` and `NotTo` assertion functions.
 
 It also supports the embedded `Not()` matcher; e.g.
 
@@ -45,9 +47,41 @@ The output of the linter,when finding issues, looks like this:
 ./testdata/src/a/a.go:22:5: ginkgo-linter: wrong length assertion; consider using `Expect("").Should(BeEmpty())` instead
 ```
 
+### Wrong `nil` Assertion
+The linter finds assertion of the comparison to nil, with all kind of matchers, instead of using the existing `BeNil()` matcher; We want to assert the item, rather than a comparison result.
+
+There are several wrong patterns:
+
+```go
+Expect(x == nil).To(Equal(true)) // should be: Expect(x).To(BeNil())
+Expect(nil == x).To(Equal(true)) // should be: Expect(x).To(BeNil())
+Expect(x != nil).To(Equal(true)) // should be: Expect(x).ToNot(BeNil())
+Expect(nil != nil).To(Equal(true)) // should be: Expect(x).ToNot(BeNil())
+
+Expect(x == nil).To(BeTrue()) // should be: Expect(x).To(BeNil())
+Expect(x == nil).To(BeFalse()) // should be: Expect(x).ToNot(BeNil())
+```
+It also supports the embedded `Not()` matcher; e.g.
+
+`Ω(x == nil).Should(Not(BeTrue()))` => `Ω(x).ShouldNot(BeNil())`
+
+Or even (double negative):
+
+`Ω(x != nil).Should(Not(BeTrue()))` => `Ω(x).Should(BeNil())`
+
 ## Suppress the linter
+### Suppress warning from command line
+* Use the `suppress-len-assertion=true` flag to suppress the wrong length assertion warning
+* Use the `suppress-nil-assertion=true` flag to suppress the wrong nil assertion warning
+
+### Suppress warning from the code
 To suppress the wrong length assertion warning, add a comment with (only)
-`ginkgo-linter:ignore-len-assert-warning`. There are two options to use this comment:
+`ginkgo-linter:ignore-len-assert-warning`. 
+
+To suppress the wrong nil assertion warning, add a comment with (only)
+`ginkgo-linter:ignore-nil-assert-warning`. 
+
+There are two options to use this comment:
 1. If the comment is at the top of the file, supress the warning for the whole file; e.g.:
    ```go
    package mypackage
@@ -65,11 +99,12 @@ To suppress the wrong length assertion warning, add a comment with (only)
         })
    })
    ```
+   
 2. If the comment is before a wrong length check expression, the warning is suppressed for this expression only; for example:
-   ```go
+   ```golang
    It("should test something", func() {
-       // ginkgo-linter:ignore-len-assert-warning
-       Expect(len("abc")).Should(Equal(3)) // this line will not trigger the warning
-       Expect(len("abc")).Should(Equal(3)) // this line will trigger the warning
+       // ginkgo-linter:ignore-nil-assert-warning
+       Expect(x == nil).Should(BeTrue()) // this line will not trigger the warning
+       Expect(x == nil).Should(BeTrue()) // this line will trigger the warning
    }
    ```

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -6,5 +6,5 @@ import (
 )
 
 func main() {
-	singlechecker.Main(ginkgolinter.Analyzer)
+	singlechecker.Main(ginkgolinter.NewAnalyzer())
 }

--- a/ginkgo_linter_test.go
+++ b/ginkgo_linter_test.go
@@ -8,6 +8,14 @@ import (
 	"github.com/nunnatsa/ginkgolinter"
 )
 
-func TestGinkgoLinter(t *testing.T) {
-	analysistest.Run(t, analysistest.TestData(), ginkgolinter.Analyzer, "a")
+func TestGinkgoLenLinter(t *testing.T) {
+	analysistest.Run(t, analysistest.TestData(), ginkgolinter.Analyzer, "a/len")
+}
+
+func TestGinkgoNilLinter(t *testing.T) {
+	analysistest.Run(t, analysistest.TestData(), ginkgolinter.Analyzer, "a/nil")
+}
+
+func TestSuppress(t *testing.T) {
+	analysistest.Run(t, analysistest.TestData(), ginkgolinter.Analyzer, "a/suppress")
 }

--- a/ginkgo_linter_test.go
+++ b/ginkgo_linter_test.go
@@ -1,6 +1,7 @@
 package ginkgolinter_test
 
 import (
+	"golang.org/x/tools/go/analysis"
 	"testing"
 
 	"golang.org/x/tools/go/analysis/analysistest"
@@ -9,13 +10,61 @@ import (
 )
 
 func TestGinkgoLenLinter(t *testing.T) {
-	analysistest.Run(t, analysistest.TestData(), ginkgolinter.Analyzer, "a/len")
+	analysistest.Run(t, analysistest.TestData(), ginkgolinter.NewAnalyzer(), "a/len")
 }
 
 func TestGinkgoNilLinter(t *testing.T) {
-	analysistest.Run(t, analysistest.TestData(), ginkgolinter.Analyzer, "a/nil")
+	analysistest.Run(t, analysistest.TestData(), ginkgolinter.NewAnalyzer(), "a/nil")
 }
 
 func TestSuppress(t *testing.T) {
-	analysistest.Run(t, analysistest.TestData(), ginkgolinter.Analyzer, "a/suppress")
+	analysistest.Run(t, analysistest.TestData(), ginkgolinter.NewAnalyzer(), "a/suppress")
+}
+
+func TestFlags_suppress_len(t *testing.T) {
+	analyzerFunc := func() *analysis.Analyzer {
+		a := ginkgolinter.NewAnalyzer()
+		err := a.Flags.Set("suppress-len-assertion", "true")
+		if err != nil {
+			t.Error(err)
+		}
+		return a
+	}
+
+	a := analyzerFunc()
+	analysistest.Run(t, analysistest.TestData(), a, "a/configlen")
+}
+
+func TestFlags_suppress_nil(t *testing.T) {
+	analyzerFunc := func() *analysis.Analyzer {
+		a := ginkgolinter.NewAnalyzer()
+		err := a.Flags.Set("suppress-nil-assertion", "true")
+		if err != nil {
+			t.Error(err)
+		}
+		return a
+	}
+
+	a := analyzerFunc()
+	analysistest.Run(t, analysistest.TestData(), a, "a/confignil")
+}
+
+func TestFlags_suppress_all(t *testing.T) {
+	analyzerFunc := func() *analysis.Analyzer {
+		a := ginkgolinter.NewAnalyzer()
+
+		err := a.Flags.Set("suppress-len-assertion", "true")
+		if err != nil {
+			t.Error(err)
+		}
+		err = a.Flags.Set("suppress-nil-assertion", "true")
+		if err != nil {
+			t.Error(err)
+		}
+
+		return a
+	}
+
+	a := analyzerFunc()
+	analysistest.Run(t, analysistest.TestData(), a, "a/configlen", "a/confignil")
 }

--- a/testdata/src/a/configlen/a.go
+++ b/testdata/src/a/configlen/a.go
@@ -1,0 +1,1485 @@
+package configlen
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("test data for the ginkgo-linter", func() {
+	Context("test Expect", func() {
+		Context("test Should", func() {
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).Should(Equal(4))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("")).Should(Equal(0))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("")).Should(BeZero())
+			})
+
+			It("should suggest ShouldNot BeEmpty", func() {
+				Expect(len("abcd")).Should(BeNumerically(">", 0))
+			})
+
+			It("should suggest ShouldNot BeEmpty", func() {
+				Expect(len("abcd")).Should(BeNumerically(">=", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				Expect(len("abcd")).Should(BeNumerically(">", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				Expect(len("abcd")).Should(BeNumerically(">=", 11))
+			})
+
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).Should(BeNumerically("==", 11))
+			})
+
+			It("should suggest ShouldNot HaveLen", func() {
+				Expect(len("abcd")).Should(BeNumerically("!=", 11))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("abcd")).Should(BeNumerically("==", 0))
+			})
+
+			It("should suggest ShouldNot BeEmpty", func() {
+				Expect(len("abcd")).Should(BeNumerically("!=", 0))
+			})
+
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).Should(Equal(len("1234")))
+			})
+		})
+		Context("test Should(Not", func() {
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).Should(Not(Equal(4)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("")).Should(Not(Equal(0)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("")).Should(Not(BeZero()))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Expect(len("abcd")).Should(Not(BeNumerically(">", 0)))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Expect(len("abcd")).Should(Not(BeNumerically(">=", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				Expect(len("abcd")).Should(Not(BeNumerically(">", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				Expect(len("abcd")).Should(Not(BeNumerically(">=", 11)))
+			})
+
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).Should(Not(BeNumerically("==", 11)))
+			})
+
+			It("should suggest Should HaveLen", func() {
+				Expect(len("abcd")).Should(Not(BeNumerically("!=", 11)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("abcd")).Should(Not(BeNumerically("==", 0)))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Expect(len("abcd")).Should(Not(BeNumerically("!=", 0)))
+			})
+
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).Should(Not(Equal(len("12345"))))
+			})
+		})
+		Context("test ShouldNot", func() {
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).ShouldNot(Equal(4))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("")).ShouldNot(Equal(0))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("")).ShouldNot(BeZero())
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Expect(len("abcd")).ShouldNot(BeNumerically(">", 0))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Expect(len("abcd")).ShouldNot(BeNumerically(">=", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				Expect(len("abcd")).ShouldNot(BeNumerically(">", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				Expect(len("abcd")).ShouldNot(BeNumerically(">=", 11))
+			})
+
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).ShouldNot(BeNumerically("==", 11))
+			})
+
+			It("should suggest Should HaveLen", func() {
+				Expect(len("abcd")).ShouldNot(BeNumerically("!=", 11))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("abcd")).ShouldNot(BeNumerically("==", 0))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Expect(len("abcd")).ShouldNot(BeNumerically("!=", 0))
+			})
+
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).ShouldNot(Equal(len("12345")))
+			})
+		})
+		Context("test ShouldNot(Not", func() {
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).ShouldNot(Not(Equal(4)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("")).ShouldNot(Not(Equal(0)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("")).ShouldNot(Not(BeZero()))
+			})
+
+			It("should suggest ShouldNot BeEmpty", func() {
+				Expect(len("abcd")).ShouldNot(Not(BeNumerically(">", 0)))
+			})
+
+			It("should suggest ShouldNot BeEmpty", func() {
+				Expect(len("abcd")).ShouldNot(Not(BeNumerically(">=", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				Expect(len("abcd")).ShouldNot(Not(BeNumerically(">", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				Expect(len("abcd")).ShouldNot(Not(BeNumerically(">=", 11)))
+			})
+
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).ShouldNot(Not(BeNumerically("==", 11)))
+			})
+
+			It("should suggest ShouldNot HaveLen", func() {
+				Expect(len("abcd")).ShouldNot(Not(BeNumerically("!=", 11)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("abcd")).ShouldNot(Not(BeNumerically("==", 0)))
+			})
+
+			It("should suggest ShouldNot BeEmpty", func() {
+				Expect(len("abcd")).ShouldNot(Not(BeNumerically("!=", 0)))
+			})
+
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).ShouldNot(Not(Equal(len("1234"))))
+			})
+		})
+		Context("test To", func() {
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).To(Equal(4))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("")).To(Equal(0))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("")).To(BeZero())
+			})
+
+			It("should suggest ToNot BeEmpty", func() {
+				Expect(len("abcd")).To(BeNumerically(">", 0))
+			})
+
+			It("should suggest ToNot BeEmpty", func() {
+				Expect(len("abcd")).To(BeNumerically(">=", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				Expect(len("abcd")).To(BeNumerically(">", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				Expect(len("abcd")).To(BeNumerically(">=", 11))
+			})
+
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).To(BeNumerically("==", 11))
+			})
+
+			It("should suggest ToNot HaveLen", func() {
+				Expect(len("abcd")).To(BeNumerically("!=", 11))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("abcd")).To(BeNumerically("==", 0))
+			})
+
+			It("should suggest ToNot BeEmpty", func() {
+				Expect(len("abcd")).To(BeNumerically("!=", 0))
+			})
+
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).To(Equal(len("1234")))
+			})
+		})
+		Context("test To(Not", func() {
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).To(Not(Equal(4)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("")).To(Not(Equal(0)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("")).To(Not(BeZero()))
+			})
+
+			It("should suggest To BeEmpty", func() {
+				Expect(len("abcd")).To(Not(BeNumerically(">", 0)))
+			})
+
+			It("should suggest To BeEmpty", func() {
+				Expect(len("abcd")).To(Not(BeNumerically(">=", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				Expect(len("abcd")).To(Not(BeNumerically(">", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				Expect(len("abcd")).To(Not(BeNumerically(">=", 11)))
+			})
+
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).To(Not(BeNumerically("==", 11)))
+			})
+
+			It("should suggest To HaveLen", func() {
+				Expect(len("abcd")).To(Not(BeNumerically("!=", 11)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("abcd")).To(Not(BeNumerically("==", 0)))
+			})
+
+			It("should suggest To BeEmpty", func() {
+				Expect(len("abcd")).To(Not(BeNumerically("!=", 0)))
+			})
+
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).To(Not(Equal(len("12345"))))
+			})
+		})
+		Context("test ToNot", func() {
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).ToNot(Equal(4))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("")).ToNot(Equal(0))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("")).ToNot(BeZero())
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Expect(len("abcd")).ToNot(BeNumerically(">", 0))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Expect(len("abcd")).ToNot(BeNumerically(">=", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				Expect(len("abcd")).ToNot(BeNumerically(">", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				Expect(len("abcd")).ToNot(BeNumerically(">=", 11))
+			})
+
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).ToNot(BeNumerically("==", 11))
+			})
+
+			It("should suggest Should HaveLen", func() {
+				Expect(len("abcd")).ToNot(BeNumerically("!=", 11))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("abcd")).ToNot(BeNumerically("==", 0))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Expect(len("abcd")).ToNot(BeNumerically("!=", 0))
+			})
+
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).ToNot(Equal(len("12345")))
+			})
+		})
+		Context("test ToNot(Not", func() {
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).ToNot(Not(Equal(4)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("")).ToNot(Not(Equal(0)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("")).ToNot(Not(BeZero()))
+			})
+
+			It("should suggest ToNot BeEmpty", func() {
+				Expect(len("abcd")).ToNot(Not(BeNumerically(">", 0)))
+			})
+
+			It("should suggest ToNot BeEmpty", func() {
+				Expect(len("abcd")).ToNot(Not(BeNumerically(">=", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				Expect(len("abcd")).ToNot(Not(BeNumerically(">", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				Expect(len("abcd")).ToNot(Not(BeNumerically(">=", 11)))
+			})
+
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).ToNot(Not(BeNumerically("==", 11)))
+			})
+
+			It("should suggest ToNot HaveLen", func() {
+				Expect(len("abcd")).ToNot(Not(BeNumerically("!=", 11)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("abcd")).ToNot(Not(BeNumerically("==", 0)))
+			})
+
+			It("should suggest ToNot BeEmpty", func() {
+				Expect(len("abcd")).ToNot(Not(BeNumerically("!=", 0)))
+			})
+
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).ToNot(Not(Equal(len("1234"))))
+			})
+		})
+		Context("test NotTo", func() {
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).NotTo(Equal(4))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("")).NotTo(Equal(0))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("")).NotTo(BeZero())
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Expect(len("abcd")).NotTo(BeNumerically(">", 0))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Expect(len("abcd")).NotTo(BeNumerically(">=", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				Expect(len("abcd")).NotTo(BeNumerically(">", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				Expect(len("abcd")).NotTo(BeNumerically(">=", 11))
+			})
+
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).NotTo(BeNumerically("==", 11))
+			})
+
+			It("should suggest Should HaveLen", func() {
+				Expect(len("abcd")).NotTo(BeNumerically("!=", 11))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("abcd")).NotTo(BeNumerically("==", 0))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Expect(len("abcd")).NotTo(BeNumerically("!=", 0))
+			})
+
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).NotTo(Equal(len("12345")))
+			})
+		})
+		Context("test NotTo(Not", func() {
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).NotTo(Not(Equal(4)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("")).NotTo(Not(Equal(0)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("")).NotTo(Not(BeZero()))
+			})
+
+			It("should suggest NotTo BeEmpty", func() {
+				Expect(len("abcd")).NotTo(Not(BeNumerically(">", 0)))
+			})
+
+			It("should suggest NotTo BeEmpty", func() {
+				Expect(len("abcd")).NotTo(Not(BeNumerically(">=", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				Expect(len("abcd")).NotTo(Not(BeNumerically(">", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				Expect(len("abcd")).NotTo(Not(BeNumerically(">=", 11)))
+			})
+
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).NotTo(Not(BeNumerically("==", 11)))
+			})
+
+			It("should suggest NotTo HaveLen", func() {
+				Expect(len("abcd")).NotTo(Not(BeNumerically("!=", 11)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Expect(len("abcd")).NotTo(Not(BeNumerically("==", 0)))
+			})
+
+			It("should suggest NotTo BeEmpty", func() {
+				Expect(len("abcd")).NotTo(Not(BeNumerically("!=", 0)))
+			})
+
+			It("should suggest HaveLen", func() {
+				Expect(len("abcd")).NotTo(Not(Equal(len("1234"))))
+			})
+		})
+	})
+	Context("test ExpectWithOffset", func() {
+		Context("test Should", func() {
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).Should(Equal(4))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("")).Should(Equal(0))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("")).Should(BeZero())
+			})
+
+			It("should suggest ShouldNot BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).Should(BeNumerically(">", 0))
+			})
+
+			It("should suggest ShouldNot BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).Should(BeNumerically(">=", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				ExpectWithOffset(12, len("abcd")).Should(BeNumerically(">", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				ExpectWithOffset(12, len("abcd")).Should(BeNumerically(">=", 11))
+			})
+
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).Should(BeNumerically("==", 11))
+			})
+
+			It("should suggest ShouldNot HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).Should(BeNumerically("!=", 11))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).Should(BeNumerically("==", 0))
+			})
+
+			It("should suggest ShouldNot BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).Should(BeNumerically("!=", 0))
+			})
+
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).Should(Equal(len("1234")))
+			})
+		})
+		Context("test Should(Not", func() {
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).Should(Not(Equal(4)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("")).Should(Not(Equal(0)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("")).Should(Not(BeZero()))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).Should(Not(BeNumerically(">", 0)))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).Should(Not(BeNumerically(">=", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				ExpectWithOffset(12, len("abcd")).Should(Not(BeNumerically(">", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				ExpectWithOffset(12, len("abcd")).Should(Not(BeNumerically(">=", 11)))
+			})
+
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).Should(Not(BeNumerically("==", 11)))
+			})
+
+			It("should suggest Should HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).Should(Not(BeNumerically("!=", 11)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).Should(Not(BeNumerically("==", 0)))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).Should(Not(BeNumerically("!=", 0)))
+			})
+
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).Should(Not(Equal(len("12345"))))
+			})
+		})
+		Context("test ShouldNot", func() {
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).ShouldNot(Equal(4))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("")).ShouldNot(Equal(0))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("")).ShouldNot(BeZero())
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).ShouldNot(BeNumerically(">", 0))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).ShouldNot(BeNumerically(">=", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				ExpectWithOffset(12, len("abcd")).ShouldNot(BeNumerically(">", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				ExpectWithOffset(12, len("abcd")).ShouldNot(BeNumerically(">=", 11))
+			})
+
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).ShouldNot(BeNumerically("==", 11))
+			})
+
+			It("should suggest Should HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).ShouldNot(BeNumerically("!=", 11))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).ShouldNot(BeNumerically("==", 0))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).ShouldNot(BeNumerically("!=", 0))
+			})
+
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).ShouldNot(Equal(len("12345")))
+			})
+		})
+		Context("test ShouldNot(Not", func() {
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(Equal(4)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("")).ShouldNot(Not(Equal(0)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("")).ShouldNot(Not(BeZero()))
+			})
+
+			It("should suggest ShouldNot BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(BeNumerically(">", 0)))
+			})
+
+			It("should suggest ShouldNot BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(BeNumerically(">=", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(BeNumerically(">", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(BeNumerically(">=", 11)))
+			})
+
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(BeNumerically("==", 11)))
+			})
+
+			It("should suggest ShouldNot HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(BeNumerically("!=", 11)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(BeNumerically("==", 0)))
+			})
+
+			It("should suggest ShouldNot BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(BeNumerically("!=", 0)))
+			})
+
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(Equal(len("1234"))))
+			})
+		})
+		Context("test To", func() {
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).To(Equal(4))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("")).To(Equal(0))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("")).To(BeZero())
+			})
+
+			It("should suggest ToNot BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).To(BeNumerically(">", 0))
+			})
+
+			It("should suggest ToNot BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).To(BeNumerically(">=", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				ExpectWithOffset(12, len("abcd")).To(BeNumerically(">", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				ExpectWithOffset(12, len("abcd")).To(BeNumerically(">=", 11))
+			})
+
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).To(BeNumerically("==", 11))
+			})
+
+			It("should suggest ToNot HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).To(BeNumerically("!=", 11))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).To(BeNumerically("==", 0))
+			})
+
+			It("should suggest ToNot BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).To(BeNumerically("!=", 0))
+			})
+
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).To(Equal(len("1234")))
+			})
+		})
+		Context("test To(Not", func() {
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).To(Not(Equal(4)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("")).To(Not(Equal(0)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("")).To(Not(BeZero()))
+			})
+
+			It("should suggest To BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).To(Not(BeNumerically(">", 0)))
+			})
+
+			It("should suggest To BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).To(Not(BeNumerically(">=", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				ExpectWithOffset(12, len("abcd")).To(Not(BeNumerically(">", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				ExpectWithOffset(12, len("abcd")).To(Not(BeNumerically(">=", 11)))
+			})
+
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).To(Not(BeNumerically("==", 11)))
+			})
+
+			It("should suggest To HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).To(Not(BeNumerically("!=", 11)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).To(Not(BeNumerically("==", 0)))
+			})
+
+			It("should suggest To BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).To(Not(BeNumerically("!=", 0)))
+			})
+
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).To(Not(Equal(len("12345"))))
+			})
+		})
+		Context("test ToNot", func() {
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).ToNot(Equal(4))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("")).ToNot(Equal(0))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("")).ToNot(BeZero())
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).ToNot(BeNumerically(">", 0))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).ToNot(BeNumerically(">=", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				ExpectWithOffset(12, len("abcd")).ToNot(BeNumerically(">", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				ExpectWithOffset(12, len("abcd")).ToNot(BeNumerically(">=", 11))
+			})
+
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).ToNot(BeNumerically("==", 11))
+			})
+
+			It("should suggest Should HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).ToNot(BeNumerically("!=", 11))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).ToNot(BeNumerically("==", 0))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).ToNot(BeNumerically("!=", 0))
+			})
+
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).ToNot(Equal(len("12345")))
+			})
+		})
+		Context("test ToNot(Not", func() {
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).ToNot(Not(Equal(4)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("")).ToNot(Not(Equal(0)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("")).ToNot(Not(BeZero()))
+			})
+
+			It("should suggest ToNot BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).ToNot(Not(BeNumerically(">", 0)))
+			})
+
+			It("should suggest ToNot BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).ToNot(Not(BeNumerically(">=", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				ExpectWithOffset(12, len("abcd")).ToNot(Not(BeNumerically(">", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				ExpectWithOffset(12, len("abcd")).ToNot(Not(BeNumerically(">=", 11)))
+			})
+
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).ToNot(Not(BeNumerically("==", 11)))
+			})
+
+			It("should suggest ToNot HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).ToNot(Not(BeNumerically("!=", 11)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).ToNot(Not(BeNumerically("==", 0)))
+			})
+
+			It("should suggest ToNot BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).ToNot(Not(BeNumerically("!=", 0)))
+			})
+
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).ToNot(Not(Equal(len("1234"))))
+			})
+		})
+		Context("test NotTo", func() {
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).NotTo(Equal(4))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("")).NotTo(Equal(0))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("")).NotTo(BeZero())
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).NotTo(BeNumerically(">", 0))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).NotTo(BeNumerically(">=", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				ExpectWithOffset(12, len("abcd")).NotTo(BeNumerically(">", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				ExpectWithOffset(12, len("abcd")).NotTo(BeNumerically(">=", 11))
+			})
+
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).NotTo(BeNumerically("==", 11))
+			})
+
+			It("should suggest Should HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).NotTo(BeNumerically("!=", 11))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).NotTo(BeNumerically("==", 0))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).NotTo(BeNumerically("!=", 0))
+			})
+
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).NotTo(Equal(len("12345")))
+			})
+		})
+		Context("test NotTo(Not", func() {
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).NotTo(Not(Equal(4)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("")).NotTo(Not(Equal(0)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("")).NotTo(Not(BeZero()))
+			})
+
+			It("should suggest NotTo BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).NotTo(Not(BeNumerically(">", 0)))
+			})
+
+			It("should suggest NotTo BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).NotTo(Not(BeNumerically(">=", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				ExpectWithOffset(12, len("abcd")).NotTo(Not(BeNumerically(">", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				ExpectWithOffset(12, len("abcd")).NotTo(Not(BeNumerically(">=", 11)))
+			})
+
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).NotTo(Not(BeNumerically("==", 11)))
+			})
+
+			It("should suggest NotTo HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).NotTo(Not(BeNumerically("!=", 11)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).NotTo(Not(BeNumerically("==", 0)))
+			})
+
+			It("should suggest NotTo BeEmpty", func() {
+				ExpectWithOffset(12, len("abcd")).NotTo(Not(BeNumerically("!=", 0)))
+			})
+
+			It("should suggest HaveLen", func() {
+				ExpectWithOffset(12, len("abcd")).NotTo(Not(Equal(len("1234"))))
+			})
+		})
+	})
+	Context("test Ω", func() {
+		Context("test Should", func() {
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).Should(Equal(4))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("")).Should(Equal(0))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("")).Should(BeZero())
+			})
+
+			It("should suggest ShouldNot BeEmpty", func() {
+				Ω(len("abcd")).Should(BeNumerically(">", 0))
+			})
+
+			It("should suggest ShouldNot BeEmpty", func() {
+				Ω(len("abcd")).Should(BeNumerically(">=", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				Ω(len("abcd")).Should(BeNumerically(">", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				Ω(len("abcd")).Should(BeNumerically(">=", 11))
+			})
+
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).Should(BeNumerically("==", 11))
+			})
+
+			It("should suggest ShouldNot HaveLen", func() {
+				Ω(len("abcd")).Should(BeNumerically("!=", 11))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("abcd")).Should(BeNumerically("==", 0))
+			})
+
+			It("should suggest ShouldNot BeEmpty", func() {
+				Ω(len("abcd")).Should(BeNumerically("!=", 0))
+			})
+
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).Should(Equal(len("1234")))
+			})
+		})
+		Context("test Should(Not", func() {
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).Should(Not(Equal(4)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("")).Should(Not(Equal(0)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("")).Should(Not(BeZero()))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Ω(len("abcd")).Should(Not(BeNumerically(">", 0)))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Ω(len("abcd")).Should(Not(BeNumerically(">=", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				Ω(len("abcd")).Should(Not(BeNumerically(">", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				Ω(len("abcd")).Should(Not(BeNumerically(">=", 11)))
+			})
+
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).Should(Not(BeNumerically("==", 11)))
+			})
+
+			It("should suggest Should HaveLen", func() {
+				Ω(len("abcd")).Should(Not(BeNumerically("!=", 11)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("abcd")).Should(Not(BeNumerically("==", 0)))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Ω(len("abcd")).Should(Not(BeNumerically("!=", 0)))
+			})
+
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).Should(Not(Equal(len("12345"))))
+			})
+		})
+		Context("test ShouldNot", func() {
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).ShouldNot(Equal(4))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("")).ShouldNot(Equal(0))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("")).ShouldNot(BeZero())
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Ω(len("abcd")).ShouldNot(BeNumerically(">", 0))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Ω(len("abcd")).ShouldNot(BeNumerically(">=", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				Ω(len("abcd")).ShouldNot(BeNumerically(">", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				Ω(len("abcd")).ShouldNot(BeNumerically(">=", 11))
+			})
+
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).ShouldNot(BeNumerically("==", 11))
+			})
+
+			It("should suggest Should HaveLen", func() {
+				Ω(len("abcd")).ShouldNot(BeNumerically("!=", 11))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("abcd")).ShouldNot(BeNumerically("==", 0))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Ω(len("abcd")).ShouldNot(BeNumerically("!=", 0))
+			})
+
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).ShouldNot(Equal(len("12345")))
+			})
+		})
+		Context("test ShouldNot(Not", func() {
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).ShouldNot(Not(Equal(4)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("")).ShouldNot(Not(Equal(0)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("")).ShouldNot(Not(BeZero()))
+			})
+
+			It("should suggest ShouldNot BeEmpty", func() {
+				Ω(len("abcd")).ShouldNot(Not(BeNumerically(">", 0)))
+			})
+
+			It("should suggest ShouldNot BeEmpty", func() {
+				Ω(len("abcd")).ShouldNot(Not(BeNumerically(">=", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				Ω(len("abcd")).ShouldNot(Not(BeNumerically(">", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				Ω(len("abcd")).ShouldNot(Not(BeNumerically(">=", 11)))
+			})
+
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).ShouldNot(Not(BeNumerically("==", 11)))
+			})
+
+			It("should suggest ShouldNot HaveLen", func() {
+				Ω(len("abcd")).ShouldNot(Not(BeNumerically("!=", 11)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("abcd")).ShouldNot(Not(BeNumerically("==", 0)))
+			})
+
+			It("should suggest ShouldNot BeEmpty", func() {
+				Ω(len("abcd")).ShouldNot(Not(BeNumerically("!=", 0)))
+			})
+
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).ShouldNot(Not(Equal(len("1234"))))
+			})
+		})
+		Context("test To", func() {
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).To(Equal(4))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("")).To(Equal(0))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("")).To(BeZero())
+			})
+
+			It("should suggest ToNot BeEmpty", func() {
+				Ω(len("abcd")).To(BeNumerically(">", 0))
+			})
+
+			It("should suggest ToNot BeEmpty", func() {
+				Ω(len("abcd")).To(BeNumerically(">=", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				Ω(len("abcd")).To(BeNumerically(">", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				Ω(len("abcd")).To(BeNumerically(">=", 11))
+			})
+
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).To(BeNumerically("==", 11))
+			})
+
+			It("should suggest ToNot HaveLen", func() {
+				Ω(len("abcd")).To(BeNumerically("!=", 11))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("abcd")).To(BeNumerically("==", 0))
+			})
+
+			It("should suggest ToNot BeEmpty", func() {
+				Ω(len("abcd")).To(BeNumerically("!=", 0))
+			})
+
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).To(Equal(len("1234")))
+			})
+		})
+		Context("test To(Not", func() {
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).To(Not(Equal(4)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("")).To(Not(Equal(0)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("")).To(Not(BeZero()))
+			})
+
+			It("should suggest To BeEmpty", func() {
+				Ω(len("abcd")).To(Not(BeNumerically(">", 0)))
+			})
+
+			It("should suggest To BeEmpty", func() {
+				Ω(len("abcd")).To(Not(BeNumerically(">=", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				Ω(len("abcd")).To(Not(BeNumerically(">", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				Ω(len("abcd")).To(Not(BeNumerically(">=", 11)))
+			})
+
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).To(Not(BeNumerically("==", 11)))
+			})
+
+			It("should suggest To HaveLen", func() {
+				Ω(len("abcd")).To(Not(BeNumerically("!=", 11)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("abcd")).To(Not(BeNumerically("==", 0)))
+			})
+
+			It("should suggest To BeEmpty", func() {
+				Ω(len("abcd")).To(Not(BeNumerically("!=", 0)))
+			})
+
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).To(Not(Equal(len("12345"))))
+			})
+		})
+		Context("test ToNot", func() {
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).ToNot(Equal(4))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("")).ToNot(Equal(0))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("")).ToNot(BeZero())
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Ω(len("abcd")).ToNot(BeNumerically(">", 0))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Ω(len("abcd")).ToNot(BeNumerically(">=", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				Ω(len("abcd")).ToNot(BeNumerically(">", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				Ω(len("abcd")).ToNot(BeNumerically(">=", 11))
+			})
+
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).ToNot(BeNumerically("==", 11))
+			})
+
+			It("should suggest Should HaveLen", func() {
+				Ω(len("abcd")).ToNot(BeNumerically("!=", 11))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("abcd")).ToNot(BeNumerically("==", 0))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Ω(len("abcd")).ToNot(BeNumerically("!=", 0))
+			})
+
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).ToNot(Equal(len("12345")))
+			})
+		})
+		Context("test ToNot(Not", func() {
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).ToNot(Not(Equal(4)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("")).ToNot(Not(Equal(0)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("")).ToNot(Not(BeZero()))
+			})
+
+			It("should suggest ToNot BeEmpty", func() {
+				Ω(len("abcd")).ToNot(Not(BeNumerically(">", 0)))
+			})
+
+			It("should suggest ToNot BeEmpty", func() {
+				Ω(len("abcd")).ToNot(Not(BeNumerically(">=", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				Ω(len("abcd")).ToNot(Not(BeNumerically(">", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				Ω(len("abcd")).ToNot(Not(BeNumerically(">=", 11)))
+			})
+
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).ToNot(Not(BeNumerically("==", 11)))
+			})
+
+			It("should suggest ToNot HaveLen", func() {
+				Ω(len("abcd")).ToNot(Not(BeNumerically("!=", 11)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("abcd")).ToNot(Not(BeNumerically("==", 0)))
+			})
+
+			It("should suggest ToNot BeEmpty", func() {
+				Ω(len("abcd")).ToNot(Not(BeNumerically("!=", 0)))
+			})
+
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).ToNot(Not(Equal(len("1234"))))
+			})
+		})
+		Context("test NotTo", func() {
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).NotTo(Equal(4))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("")).NotTo(Equal(0))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("")).NotTo(BeZero())
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Ω(len("abcd")).NotTo(BeNumerically(">", 0))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Ω(len("abcd")).NotTo(BeNumerically(">=", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				Ω(len("abcd")).NotTo(BeNumerically(">", 1))
+			})
+
+			It("should ignore other lengths", func() {
+				Ω(len("abcd")).NotTo(BeNumerically(">=", 11))
+			})
+
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).NotTo(BeNumerically("==", 11))
+			})
+
+			It("should suggest Should HaveLen", func() {
+				Ω(len("abcd")).NotTo(BeNumerically("!=", 11))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("abcd")).NotTo(BeNumerically("==", 0))
+			})
+
+			It("should suggest Should BeEmpty", func() {
+				Ω(len("abcd")).NotTo(BeNumerically("!=", 0))
+			})
+
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).NotTo(Equal(len("12345")))
+			})
+		})
+		Context("test NotTo(Not", func() {
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).NotTo(Not(Equal(4)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("")).NotTo(Not(Equal(0)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("")).NotTo(Not(BeZero()))
+			})
+
+			It("should suggest NotTo BeEmpty", func() {
+				Ω(len("abcd")).NotTo(Not(BeNumerically(">", 0)))
+			})
+
+			It("should suggest NotTo BeEmpty", func() {
+				Ω(len("abcd")).NotTo(Not(BeNumerically(">=", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				Ω(len("abcd")).NotTo(Not(BeNumerically(">", 1)))
+			})
+
+			It("should ignore other lengths", func() {
+				Ω(len("abcd")).NotTo(Not(BeNumerically(">=", 11)))
+			})
+
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).NotTo(Not(BeNumerically("==", 11)))
+			})
+
+			It("should suggest NotTo HaveLen", func() {
+				Ω(len("abcd")).NotTo(Not(BeNumerically("!=", 11)))
+			})
+
+			It("should suggest BeEmpty", func() {
+				Ω(len("abcd")).NotTo(Not(BeNumerically("==", 0)))
+			})
+
+			It("should suggest NotTo BeEmpty", func() {
+				Ω(len("abcd")).NotTo(Not(BeNumerically("!=", 0)))
+			})
+
+			It("should suggest HaveLen", func() {
+				Ω(len("abcd")).NotTo(Not(Equal(len("1234"))))
+			})
+		})
+	})
+})

--- a/testdata/src/a/confignil/a.go
+++ b/testdata/src/a/confignil/a.go
@@ -1,0 +1,1594 @@
+package confignil
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func fNil() *string {
+	return nil
+}
+
+func fNotNil() *string {
+	val := "no nil"
+	return &val
+}
+
+var _ = Describe("", func() {
+
+	var x *int
+	val := 3
+	y := &val
+
+	Context("test Expect", func() {
+		Context("test Should", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Expect(x == nil).Should(BeTrue())
+					Expect(nil == x).Should(BeTrue())
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).Should(BeTrue())
+					Expect(nil != y).Should(BeTrue())
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).Should(BeTrue())
+					Expect(nil == fNil()).Should(BeTrue())
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).Should(BeTrue())
+					Expect(nil != fNotNil()).Should(BeTrue())
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Expect(x != nil).Should(BeFalse())
+					Expect(nil != x).Should(BeFalse())
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).Should(BeFalse())
+					Expect(nil == y).Should(BeFalse())
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).Should(BeFalse())
+					Expect(nil != fNil()).Should(BeFalse())
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).Should(BeFalse())
+					Expect(nil == fNotNil()).Should(BeFalse())
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Expect(x == nil).Should(Equal(true))
+					Expect(nil == x).Should(Equal(true))
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).Should(Equal(true))
+					Expect(nil != y).Should(Equal(true))
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).Should(Equal(true))
+					Expect(nil == fNil()).Should(Equal(true))
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).Should(Equal(true))
+					Expect(nil != fNotNil()).Should(Equal(true))
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Expect(x != nil).Should(Equal(false))
+					Expect(nil != x).Should(Equal(false))
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).Should(Equal(false))
+					Expect(nil == y).Should(Equal(false))
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).Should(Equal(false))
+					Expect(nil != fNil()).Should(Equal(false))
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).Should(Equal(false))
+					Expect(nil == fNotNil()).Should(Equal(false))
+				})
+			})
+		})
+		Context("test Should(Not())", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Expect(x == nil).Should(Not(BeFalse()))
+					Expect(nil == x).Should(Not(BeFalse()))
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).Should(Not(BeFalse()))
+					Expect(nil != y).Should(Not(BeFalse()))
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).Should(Not(BeFalse()))
+					Expect(nil == fNil()).Should(Not(BeFalse()))
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).Should(Not(BeFalse()))
+					Expect(nil != fNotNil()).Should(Not(BeFalse()))
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Expect(x != nil).Should(Not(BeTrue()))
+					Expect(nil != x).Should(Not(BeTrue()))
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).Should(Not(BeTrue()))
+					Expect(nil == y).Should(Not(BeTrue()))
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).Should(Not(BeTrue()))
+					Expect(nil != fNil()).Should(Not(BeTrue()))
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).Should(Not(BeTrue()))
+					Expect(nil == fNotNil()).Should(Not(BeTrue()))
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Expect(x == nil).Should(Not(Equal(false)))
+					Expect(nil == x).Should(Not(Equal(false)))
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).Should(Not(Equal(false)))
+					Expect(nil != y).Should(Not(Equal(false)))
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).Should(Not(Equal(false)))
+					Expect(nil == fNil()).Should(Not(Equal(false)))
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).Should(Not(Equal(false)))
+					Expect(nil != fNotNil()).Should(Not(Equal(false)))
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Expect(x != nil).Should(Not(Equal(true)))
+					Expect(nil != x).Should(Not(Equal(true)))
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).Should(Not(Equal(true)))
+					Expect(nil == y).Should(Not(Equal(true)))
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).Should(Not(Equal(true)))
+					Expect(nil != fNil()).Should(Not(Equal(true)))
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).Should(Not(Equal(true)))
+					Expect(nil == fNotNil()).Should(Not(Equal(true)))
+				})
+			})
+		})
+
+		Context("test To", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Expect(x == nil).To(BeTrue())
+					Expect(nil == x).To(BeTrue())
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).To(BeTrue())
+					Expect(nil != y).To(BeTrue())
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).To(BeTrue())
+					Expect(nil == fNil()).To(BeTrue())
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).To(BeTrue())
+					Expect(nil != fNotNil()).To(BeTrue())
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Expect(x != nil).To(BeFalse())
+					Expect(nil != x).To(BeFalse())
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).To(BeFalse())
+					Expect(nil == y).To(BeFalse())
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).To(BeFalse())
+					Expect(nil != fNil()).To(BeFalse())
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).To(BeFalse())
+					Expect(nil == fNotNil()).To(BeFalse())
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Expect(x == nil).To(Equal(true))
+					Expect(nil == x).To(Equal(true))
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).To(Equal(true))
+					Expect(nil != y).To(Equal(true))
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).To(Equal(true))
+					Expect(nil == fNil()).To(Equal(true))
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).To(Equal(true))
+					Expect(nil != fNotNil()).To(Equal(true))
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Expect(x != nil).To(Equal(false))
+					Expect(nil != x).To(Equal(false))
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).To(Equal(false))
+					Expect(nil == y).To(Equal(false))
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).To(Equal(false))
+					Expect(nil != fNil()).To(Equal(false))
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).To(Equal(false))
+					Expect(nil == fNotNil()).To(Equal(false))
+				})
+			})
+		})
+		Context("test To(Not())", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Expect(x == nil).To(Not(BeFalse()))
+					Expect(nil == x).To(Not(BeFalse()))
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).To(Not(BeFalse()))
+					Expect(nil != y).To(Not(BeFalse()))
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).To(Not(BeFalse()))
+					Expect(nil == fNil()).To(Not(BeFalse()))
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).To(Not(BeFalse()))
+					Expect(nil != fNotNil()).To(Not(BeFalse()))
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Expect(x != nil).To(Not(BeTrue()))
+					Expect(nil != x).To(Not(BeTrue()))
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).To(Not(BeTrue()))
+					Expect(nil == y).To(Not(BeTrue()))
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).To(Not(BeTrue()))
+					Expect(nil != fNil()).To(Not(BeTrue()))
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).To(Not(BeTrue()))
+					Expect(nil == fNotNil()).To(Not(BeTrue()))
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Expect(x == nil).To(Not(Equal(false)))
+					Expect(nil == x).To(Not(Equal(false)))
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).To(Not(Equal(false)))
+					Expect(nil != y).To(Not(Equal(false)))
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).To(Not(Equal(false)))
+					Expect(nil == fNil()).To(Not(Equal(false)))
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).To(Not(Equal(false)))
+					Expect(nil != fNotNil()).To(Not(Equal(false)))
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Expect(x != nil).To(Not(Equal(true)))
+					Expect(nil != x).To(Not(Equal(true)))
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).To(Not(Equal(true)))
+					Expect(nil == y).To(Not(Equal(true)))
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).To(Not(Equal(true)))
+					Expect(nil != fNil()).To(Not(Equal(true)))
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).To(Not(Equal(true)))
+					Expect(nil == fNotNil()).To(Not(Equal(true)))
+				})
+			})
+		})
+
+		Context("test ShouldNot", func() {
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Expect(x == nil).ShouldNot(BeFalse())
+					Expect(nil == x).ShouldNot(BeFalse())
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).ShouldNot(BeFalse())
+					Expect(nil != y).ShouldNot(BeFalse())
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).ShouldNot(BeFalse())
+					Expect(nil == fNil()).ShouldNot(BeFalse())
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).ShouldNot(BeFalse())
+					Expect(nil != fNotNil()).ShouldNot(BeFalse())
+				})
+			})
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Expect(x != nil).ShouldNot(BeTrue())
+					Expect(nil != x).ShouldNot(BeTrue())
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).ShouldNot(BeTrue())
+					Expect(nil == y).ShouldNot(BeTrue())
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).ShouldNot(BeTrue())
+					Expect(nil != fNil()).ShouldNot(BeTrue())
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).ShouldNot(BeTrue())
+					Expect(nil == fNotNil()).ShouldNot(BeTrue())
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Expect(x != nil).ShouldNot(Equal(true))
+					Expect(nil != x).ShouldNot(Equal(true))
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).ShouldNot(Equal(true))
+					Expect(nil == y).ShouldNot(Equal(true))
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).ShouldNot(Equal(true))
+					Expect(nil != fNil()).ShouldNot(Equal(true))
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).ShouldNot(Equal(true))
+					Expect(nil == fNotNil()).ShouldNot(Equal(true))
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Expect(x == nil).ShouldNot(Equal(false))
+					Expect(nil == x).ShouldNot(Equal(false))
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).ShouldNot(Equal(false))
+					Expect(nil != y).ShouldNot(Equal(false))
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).ShouldNot(Equal(false))
+					Expect(nil == fNil()).ShouldNot(Equal(false))
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).ShouldNot(Equal(false))
+					Expect(nil != fNotNil()).ShouldNot(Equal(false))
+				})
+			})
+		})
+
+		Context("test NotTo", func() {
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Expect(x == nil).NotTo(BeFalse())
+					Expect(nil == x).NotTo(BeFalse())
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).NotTo(BeFalse())
+					Expect(nil != y).NotTo(BeFalse())
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).NotTo(BeFalse())
+					Expect(nil == fNil()).NotTo(BeFalse())
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).NotTo(BeFalse())
+					Expect(nil != fNotNil()).NotTo(BeFalse())
+				})
+			})
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Expect(x != nil).NotTo(BeTrue())
+					Expect(nil != x).NotTo(BeTrue())
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).NotTo(BeTrue())
+					Expect(nil == y).NotTo(BeTrue())
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).NotTo(BeTrue())
+					Expect(nil != fNil()).NotTo(BeTrue())
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).NotTo(BeTrue())
+					Expect(nil == fNotNil()).NotTo(BeTrue())
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Expect(x != nil).NotTo(Equal(true))
+					Expect(nil != x).NotTo(Equal(true))
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).NotTo(Equal(true))
+					Expect(nil == y).NotTo(Equal(true))
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).NotTo(Equal(true))
+					Expect(nil != fNil()).NotTo(Equal(true))
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).NotTo(Equal(true))
+					Expect(nil == fNotNil()).NotTo(Equal(true))
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Expect(x == nil).NotTo(Equal(false))
+					Expect(nil == x).NotTo(Equal(false))
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).NotTo(Equal(false))
+					Expect(nil != y).NotTo(Equal(false))
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).NotTo(Equal(false))
+					Expect(nil == fNil()).NotTo(Equal(false))
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).NotTo(Equal(false))
+					Expect(nil != fNotNil()).NotTo(Equal(false))
+				})
+			})
+		})
+		Context("test ToNot", func() {
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Expect(x == nil).ToNot(BeFalse())
+					Expect(nil == x).ToNot(BeFalse())
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).ToNot(BeFalse())
+					Expect(nil != y).ToNot(BeFalse())
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).ToNot(BeFalse())
+					Expect(nil == fNil()).ToNot(BeFalse())
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).ToNot(BeFalse())
+					Expect(nil != fNotNil()).ToNot(BeFalse())
+				})
+			})
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Expect(x != nil).ToNot(BeTrue())
+					Expect(nil != x).ToNot(BeTrue())
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).ToNot(BeTrue())
+					Expect(nil == y).ToNot(BeTrue())
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).ToNot(BeTrue())
+					Expect(nil != fNil()).ToNot(BeTrue())
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).ToNot(BeTrue())
+					Expect(nil == fNotNil()).ToNot(BeTrue())
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Expect(x != nil).ToNot(Equal(true))
+					Expect(nil != x).ToNot(Equal(true))
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).ToNot(Equal(true))
+					Expect(nil == y).ToNot(Equal(true))
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).ToNot(Equal(true))
+					Expect(nil != fNil()).ToNot(Equal(true))
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).ToNot(Equal(true))
+					Expect(nil == fNotNil()).ToNot(Equal(true))
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Expect(x == nil).ToNot(Equal(false))
+					Expect(nil == x).ToNot(Equal(false))
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).ToNot(Equal(false))
+					Expect(nil != y).ToNot(Equal(false))
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).ToNot(Equal(false))
+					Expect(nil == fNil()).ToNot(Equal(false))
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).ToNot(Equal(false))
+					Expect(nil != fNotNil()).ToNot(Equal(false))
+				})
+			})
+		})
+	})
+
+	Context("test ExpectWithOffset", func() {
+		Context("test Should", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).Should(BeTrue())
+					ExpectWithOffset(1, nil == x).Should(BeTrue())
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).Should(BeTrue())
+					ExpectWithOffset(1, nil != y).Should(BeTrue())
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).Should(BeTrue())
+					ExpectWithOffset(1, nil == fNil()).Should(BeTrue())
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).Should(BeTrue())
+					ExpectWithOffset(1, nil != fNotNil()).Should(BeTrue())
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).Should(BeFalse())
+					ExpectWithOffset(1, nil != x).Should(BeFalse())
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).Should(BeFalse())
+					ExpectWithOffset(1, nil == y).Should(BeFalse())
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).Should(BeFalse())
+					ExpectWithOffset(1, nil != fNil()).Should(BeFalse())
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).Should(BeFalse())
+					ExpectWithOffset(1, nil == fNotNil()).Should(BeFalse())
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).Should(Equal(true))
+					ExpectWithOffset(1, nil == x).Should(Equal(true))
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).Should(Equal(true))
+					ExpectWithOffset(1, nil != y).Should(Equal(true))
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).Should(Equal(true))
+					ExpectWithOffset(1, nil == fNil()).Should(Equal(true))
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).Should(Equal(true))
+					ExpectWithOffset(1, nil != fNotNil()).Should(Equal(true))
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).Should(Equal(false))
+					ExpectWithOffset(1, nil != x).Should(Equal(false))
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).Should(Equal(false))
+					ExpectWithOffset(1, nil == y).Should(Equal(false))
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).Should(Equal(false))
+					ExpectWithOffset(1, nil != fNil()).Should(Equal(false))
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).Should(Equal(false))
+					ExpectWithOffset(1, nil == fNotNil()).Should(Equal(false))
+				})
+			})
+		})
+		Context("test Should(Not())", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).Should(Not(BeFalse()))
+					ExpectWithOffset(1, nil == x).Should(Not(BeFalse()))
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).Should(Not(BeFalse()))
+					ExpectWithOffset(1, nil != y).Should(Not(BeFalse()))
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).Should(Not(BeFalse()))
+					ExpectWithOffset(1, nil == fNil()).Should(Not(BeFalse()))
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).Should(Not(BeFalse()))
+					ExpectWithOffset(1, nil != fNotNil()).Should(Not(BeFalse()))
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).Should(Not(BeTrue()))
+					ExpectWithOffset(1, nil != x).Should(Not(BeTrue()))
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).Should(Not(BeTrue()))
+					ExpectWithOffset(1, nil == y).Should(Not(BeTrue()))
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).Should(Not(BeTrue()))
+					ExpectWithOffset(1, nil != fNil()).Should(Not(BeTrue()))
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).Should(Not(BeTrue()))
+					ExpectWithOffset(1, nil == fNotNil()).Should(Not(BeTrue()))
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).Should(Not(Equal(false)))
+					ExpectWithOffset(1, nil == x).Should(Not(Equal(false)))
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).Should(Not(Equal(false)))
+					ExpectWithOffset(1, nil != y).Should(Not(Equal(false)))
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).Should(Not(Equal(false)))
+					ExpectWithOffset(1, nil == fNil()).Should(Not(Equal(false)))
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).Should(Not(Equal(false)))
+					ExpectWithOffset(1, nil != fNotNil()).Should(Not(Equal(false)))
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).Should(Not(Equal(true)))
+					ExpectWithOffset(1, nil != x).Should(Not(Equal(true)))
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).Should(Not(Equal(true)))
+					ExpectWithOffset(1, nil == y).Should(Not(Equal(true)))
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).Should(Not(Equal(true)))
+					ExpectWithOffset(1, nil != fNil()).Should(Not(Equal(true)))
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).Should(Not(Equal(true)))
+					ExpectWithOffset(1, nil == fNotNil()).Should(Not(Equal(true)))
+				})
+			})
+		})
+
+		Context("test To", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).To(BeTrue())
+					ExpectWithOffset(1, nil == x).To(BeTrue())
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).To(BeTrue())
+					ExpectWithOffset(1, nil != y).To(BeTrue())
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).To(BeTrue())
+					ExpectWithOffset(1, nil == fNil()).To(BeTrue())
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).To(BeTrue())
+					ExpectWithOffset(1, nil != fNotNil()).To(BeTrue())
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).To(BeFalse())
+					ExpectWithOffset(1, nil != x).To(BeFalse())
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).To(BeFalse())
+					ExpectWithOffset(1, nil == y).To(BeFalse())
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).To(BeFalse())
+					ExpectWithOffset(1, nil != fNil()).To(BeFalse())
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).To(BeFalse())
+					ExpectWithOffset(1, nil == fNotNil()).To(BeFalse())
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).To(Equal(true))
+					ExpectWithOffset(1, nil == x).To(Equal(true))
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).To(Equal(true))
+					ExpectWithOffset(1, nil != y).To(Equal(true))
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).To(Equal(true))
+					ExpectWithOffset(1, nil == fNil()).To(Equal(true))
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).To(Equal(true))
+					ExpectWithOffset(1, nil != fNotNil()).To(Equal(true))
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).To(Equal(false))
+					ExpectWithOffset(1, nil != x).To(Equal(false))
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).To(Equal(false))
+					ExpectWithOffset(1, nil == y).To(Equal(false))
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).To(Equal(false))
+					ExpectWithOffset(1, nil != fNil()).To(Equal(false))
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).To(Equal(false))
+					ExpectWithOffset(1, nil == fNotNil()).To(Equal(false))
+				})
+			})
+		})
+		Context("test To(Not())", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).To(Not(BeFalse()))
+					ExpectWithOffset(1, nil == x).To(Not(BeFalse()))
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).To(Not(BeFalse()))
+					ExpectWithOffset(1, nil != y).To(Not(BeFalse()))
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).To(Not(BeFalse()))
+					ExpectWithOffset(1, nil == fNil()).To(Not(BeFalse()))
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).To(Not(BeFalse()))
+					ExpectWithOffset(1, nil != fNotNil()).To(Not(BeFalse()))
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).To(Not(BeTrue()))
+					ExpectWithOffset(1, nil != x).To(Not(BeTrue()))
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).To(Not(BeTrue()))
+					ExpectWithOffset(1, nil == y).To(Not(BeTrue()))
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).To(Not(BeTrue()))
+					ExpectWithOffset(1, nil != fNil()).To(Not(BeTrue()))
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).To(Not(BeTrue()))
+					ExpectWithOffset(1, nil == fNotNil()).To(Not(BeTrue()))
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).To(Not(Equal(false)))
+					ExpectWithOffset(1, nil == x).To(Not(Equal(false)))
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).To(Not(Equal(false)))
+					ExpectWithOffset(1, nil != y).To(Not(Equal(false)))
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).To(Not(Equal(false)))
+					ExpectWithOffset(1, nil == fNil()).To(Not(Equal(false)))
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).To(Not(Equal(false)))
+					ExpectWithOffset(1, nil != fNotNil()).To(Not(Equal(false)))
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).To(Not(Equal(true)))
+					ExpectWithOffset(1, nil != x).To(Not(Equal(true)))
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).To(Not(Equal(true)))
+					ExpectWithOffset(1, nil == y).To(Not(Equal(true)))
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).To(Not(Equal(true)))
+					ExpectWithOffset(1, nil != fNil()).To(Not(Equal(true)))
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).To(Not(Equal(true)))
+					ExpectWithOffset(1, nil == fNotNil()).To(Not(Equal(true)))
+				})
+			})
+		})
+
+		Context("test ShouldNot", func() {
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).ShouldNot(BeFalse())
+					ExpectWithOffset(1, nil == x).ShouldNot(BeFalse())
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).ShouldNot(BeFalse())
+					ExpectWithOffset(1, nil != y).ShouldNot(BeFalse())
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).ShouldNot(BeFalse())
+					ExpectWithOffset(1, nil == fNil()).ShouldNot(BeFalse())
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).ShouldNot(BeFalse())
+					ExpectWithOffset(1, nil != fNotNil()).ShouldNot(BeFalse())
+				})
+			})
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).ShouldNot(BeTrue())
+					ExpectWithOffset(1, nil != x).ShouldNot(BeTrue())
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).ShouldNot(BeTrue())
+					ExpectWithOffset(1, nil == y).ShouldNot(BeTrue())
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).ShouldNot(BeTrue())
+					ExpectWithOffset(1, nil != fNil()).ShouldNot(BeTrue())
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).ShouldNot(BeTrue())
+					ExpectWithOffset(1, nil == fNotNil()).ShouldNot(BeTrue())
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).ShouldNot(Equal(true))
+					ExpectWithOffset(1, nil != x).ShouldNot(Equal(true))
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).ShouldNot(Equal(true))
+					ExpectWithOffset(1, nil == y).ShouldNot(Equal(true))
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).ShouldNot(Equal(true))
+					ExpectWithOffset(1, nil != fNil()).ShouldNot(Equal(true))
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).ShouldNot(Equal(true))
+					ExpectWithOffset(1, nil == fNotNil()).ShouldNot(Equal(true))
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).ShouldNot(Equal(false))
+					ExpectWithOffset(1, nil == x).ShouldNot(Equal(false))
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).ShouldNot(Equal(false))
+					ExpectWithOffset(1, nil != y).ShouldNot(Equal(false))
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).ShouldNot(Equal(false))
+					ExpectWithOffset(1, nil == fNil()).ShouldNot(Equal(false))
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).ShouldNot(Equal(false))
+					ExpectWithOffset(1, nil != fNotNil()).ShouldNot(Equal(false))
+				})
+			})
+		})
+
+		Context("test NotTo", func() {
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).NotTo(BeFalse())
+					ExpectWithOffset(1, nil == x).NotTo(BeFalse())
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).NotTo(BeFalse())
+					ExpectWithOffset(1, nil != y).NotTo(BeFalse())
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).NotTo(BeFalse())
+					ExpectWithOffset(1, nil == fNil()).NotTo(BeFalse())
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).NotTo(BeFalse())
+					ExpectWithOffset(1, nil != fNotNil()).NotTo(BeFalse())
+				})
+			})
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).NotTo(BeTrue())
+					ExpectWithOffset(1, nil != x).NotTo(BeTrue())
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).NotTo(BeTrue())
+					ExpectWithOffset(1, nil == y).NotTo(BeTrue())
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).NotTo(BeTrue())
+					ExpectWithOffset(1, nil != fNil()).NotTo(BeTrue())
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).NotTo(BeTrue())
+					ExpectWithOffset(1, nil == fNotNil()).NotTo(BeTrue())
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).NotTo(Equal(true))
+					ExpectWithOffset(1, nil != x).NotTo(Equal(true))
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).NotTo(Equal(true))
+					ExpectWithOffset(1, nil == y).NotTo(Equal(true))
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).NotTo(Equal(true))
+					ExpectWithOffset(1, nil != fNil()).NotTo(Equal(true))
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).NotTo(Equal(true))
+					ExpectWithOffset(1, nil == fNotNil()).NotTo(Equal(true))
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).NotTo(Equal(false))
+					ExpectWithOffset(1, nil == x).NotTo(Equal(false))
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).NotTo(Equal(false))
+					ExpectWithOffset(1, nil != y).NotTo(Equal(false))
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).NotTo(Equal(false))
+					ExpectWithOffset(1, nil == fNil()).NotTo(Equal(false))
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).NotTo(Equal(false))
+					ExpectWithOffset(1, nil != fNotNil()).NotTo(Equal(false))
+				})
+			})
+		})
+		Context("test ToNot", func() {
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).ToNot(BeFalse())
+					ExpectWithOffset(1, nil == x).ToNot(BeFalse())
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).ToNot(BeFalse())
+					ExpectWithOffset(1, nil != y).ToNot(BeFalse())
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).ToNot(BeFalse())
+					ExpectWithOffset(1, nil == fNil()).ToNot(BeFalse())
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).ToNot(BeFalse())
+					ExpectWithOffset(1, nil != fNotNil()).ToNot(BeFalse())
+				})
+			})
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).ToNot(BeTrue())
+					ExpectWithOffset(1, nil != x).ToNot(BeTrue())
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).ToNot(BeTrue())
+					ExpectWithOffset(1, nil == y).ToNot(BeTrue())
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).ToNot(BeTrue())
+					ExpectWithOffset(1, nil != fNil()).ToNot(BeTrue())
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).ToNot(BeTrue())
+					ExpectWithOffset(1, nil == fNotNil()).ToNot(BeTrue())
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).ToNot(Equal(true))
+					ExpectWithOffset(1, nil != x).ToNot(Equal(true))
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).ToNot(Equal(true))
+					ExpectWithOffset(1, nil == y).ToNot(Equal(true))
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).ToNot(Equal(true))
+					ExpectWithOffset(1, nil != fNil()).ToNot(Equal(true))
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).ToNot(Equal(true))
+					ExpectWithOffset(1, nil == fNotNil()).ToNot(Equal(true))
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).ToNot(Equal(false))
+					ExpectWithOffset(1, nil == x).ToNot(Equal(false))
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).ToNot(Equal(false))
+					ExpectWithOffset(1, nil != y).ToNot(Equal(false))
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).ToNot(Equal(false))
+					ExpectWithOffset(1, nil == fNil()).ToNot(Equal(false))
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).ToNot(Equal(false))
+					ExpectWithOffset(1, nil != fNotNil()).ToNot(Equal(false))
+				})
+			})
+		})
+	})
+
+	Context("test Ω", func() {
+		Context("test Should", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Ω(x == nil).Should(BeTrue())
+					Ω(nil == x).Should(BeTrue())
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).Should(BeTrue())
+					Ω(nil != y).Should(BeTrue())
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).Should(BeTrue())
+					Ω(nil == fNil()).Should(BeTrue())
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).Should(BeTrue())
+					Ω(nil != fNotNil()).Should(BeTrue())
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Ω(x != nil).Should(BeFalse())
+					Ω(nil != x).Should(BeFalse())
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).Should(BeFalse())
+					Ω(nil == y).Should(BeFalse())
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).Should(BeFalse())
+					Ω(nil != fNil()).Should(BeFalse())
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).Should(BeFalse())
+					Ω(nil == fNotNil()).Should(BeFalse())
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Ω(x == nil).Should(Equal(true))
+					Ω(nil == x).Should(Equal(true))
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).Should(Equal(true))
+					Ω(nil != y).Should(Equal(true))
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).Should(Equal(true))
+					Ω(nil == fNil()).Should(Equal(true))
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).Should(Equal(true))
+					Ω(nil != fNotNil()).Should(Equal(true))
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Ω(x != nil).Should(Equal(false))
+					Ω(nil != x).Should(Equal(false))
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).Should(Equal(false))
+					Ω(nil == y).Should(Equal(false))
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).Should(Equal(false))
+					Ω(nil != fNil()).Should(Equal(false))
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).Should(Equal(false))
+					Ω(nil == fNotNil()).Should(Equal(false))
+				})
+			})
+		})
+		Context("test Should(Not())", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Ω(x == nil).Should(Not(BeFalse()))
+					Ω(nil == x).Should(Not(BeFalse()))
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).Should(Not(BeFalse()))
+					Ω(nil != y).Should(Not(BeFalse()))
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).Should(Not(BeFalse()))
+					Ω(nil == fNil()).Should(Not(BeFalse()))
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).Should(Not(BeFalse()))
+					Ω(nil != fNotNil()).Should(Not(BeFalse()))
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Ω(x != nil).Should(Not(BeTrue()))
+					Ω(nil != x).Should(Not(BeTrue()))
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).Should(Not(BeTrue()))
+					Ω(nil == y).Should(Not(BeTrue()))
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).Should(Not(BeTrue()))
+					Ω(nil != fNil()).Should(Not(BeTrue()))
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).Should(Not(BeTrue()))
+					Ω(nil == fNotNil()).Should(Not(BeTrue()))
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Ω(x == nil).Should(Not(Equal(false)))
+					Ω(nil == x).Should(Not(Equal(false)))
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).Should(Not(Equal(false)))
+					Ω(nil != y).Should(Not(Equal(false)))
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).Should(Not(Equal(false)))
+					Ω(nil == fNil()).Should(Not(Equal(false)))
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).Should(Not(Equal(false)))
+					Ω(nil != fNotNil()).Should(Not(Equal(false)))
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Ω(x != nil).Should(Not(Equal(true)))
+					Ω(nil != x).Should(Not(Equal(true)))
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).Should(Not(Equal(true)))
+					Ω(nil == y).Should(Not(Equal(true)))
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).Should(Not(Equal(true)))
+					Ω(nil != fNil()).Should(Not(Equal(true)))
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).Should(Not(Equal(true)))
+					Ω(nil == fNotNil()).Should(Not(Equal(true)))
+				})
+			})
+		})
+
+		Context("test To", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Ω(x == nil).To(BeTrue())
+					Ω(nil == x).To(BeTrue())
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).To(BeTrue())
+					Ω(nil != y).To(BeTrue())
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).To(BeTrue())
+					Ω(nil == fNil()).To(BeTrue())
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).To(BeTrue())
+					Ω(nil != fNotNil()).To(BeTrue())
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Ω(x != nil).To(BeFalse())
+					Ω(nil != x).To(BeFalse())
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).To(BeFalse())
+					Ω(nil == y).To(BeFalse())
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).To(BeFalse())
+					Ω(nil != fNil()).To(BeFalse())
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).To(BeFalse())
+					Ω(nil == fNotNil()).To(BeFalse())
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Ω(x == nil).To(Equal(true))
+					Ω(nil == x).To(Equal(true))
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).To(Equal(true))
+					Ω(nil != y).To(Equal(true))
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).To(Equal(true))
+					Ω(nil == fNil()).To(Equal(true))
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).To(Equal(true))
+					Ω(nil != fNotNil()).To(Equal(true))
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Ω(x != nil).To(Equal(false))
+					Ω(nil != x).To(Equal(false))
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).To(Equal(false))
+					Ω(nil == y).To(Equal(false))
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).To(Equal(false))
+					Ω(nil != fNil()).To(Equal(false))
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).To(Equal(false))
+					Ω(nil == fNotNil()).To(Equal(false))
+				})
+			})
+		})
+		Context("test To(Not())", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Ω(x == nil).To(Not(BeFalse()))
+					Ω(nil == x).To(Not(BeFalse()))
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).To(Not(BeFalse()))
+					Ω(nil != y).To(Not(BeFalse()))
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).To(Not(BeFalse()))
+					Ω(nil == fNil()).To(Not(BeFalse()))
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).To(Not(BeFalse()))
+					Ω(nil != fNotNil()).To(Not(BeFalse()))
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Ω(x != nil).To(Not(BeTrue()))
+					Ω(nil != x).To(Not(BeTrue()))
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).To(Not(BeTrue()))
+					Ω(nil == y).To(Not(BeTrue()))
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).To(Not(BeTrue()))
+					Ω(nil != fNil()).To(Not(BeTrue()))
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).To(Not(BeTrue()))
+					Ω(nil == fNotNil()).To(Not(BeTrue()))
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Ω(x == nil).To(Not(Equal(false)))
+					Ω(nil == x).To(Not(Equal(false)))
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).To(Not(Equal(false)))
+					Ω(nil != y).To(Not(Equal(false)))
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).To(Not(Equal(false)))
+					Ω(nil == fNil()).To(Not(Equal(false)))
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).To(Not(Equal(false)))
+					Ω(nil != fNotNil()).To(Not(Equal(false)))
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Ω(x != nil).To(Not(Equal(true)))
+					Ω(nil != x).To(Not(Equal(true)))
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).To(Not(Equal(true)))
+					Ω(nil == y).To(Not(Equal(true)))
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).To(Not(Equal(true)))
+					Ω(nil != fNil()).To(Not(Equal(true)))
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).To(Not(Equal(true)))
+					Ω(nil == fNotNil()).To(Not(Equal(true)))
+				})
+			})
+		})
+
+		Context("test ShouldNot", func() {
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Ω(x == nil).ShouldNot(BeFalse())
+					Ω(nil == x).ShouldNot(BeFalse())
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).ShouldNot(BeFalse())
+					Ω(nil != y).ShouldNot(BeFalse())
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).ShouldNot(BeFalse())
+					Ω(nil == fNil()).ShouldNot(BeFalse())
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).ShouldNot(BeFalse())
+					Ω(nil != fNotNil()).ShouldNot(BeFalse())
+				})
+			})
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Ω(x != nil).ShouldNot(BeTrue())
+					Ω(nil != x).ShouldNot(BeTrue())
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).ShouldNot(BeTrue())
+					Ω(nil == y).ShouldNot(BeTrue())
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).ShouldNot(BeTrue())
+					Ω(nil != fNil()).ShouldNot(BeTrue())
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).ShouldNot(BeTrue())
+					Ω(nil == fNotNil()).ShouldNot(BeTrue())
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Ω(x != nil).ShouldNot(Equal(true))
+					Ω(nil != x).ShouldNot(Equal(true))
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).ShouldNot(Equal(true))
+					Ω(nil == y).ShouldNot(Equal(true))
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).ShouldNot(Equal(true))
+					Ω(nil != fNil()).ShouldNot(Equal(true))
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).ShouldNot(Equal(true))
+					Ω(nil == fNotNil()).ShouldNot(Equal(true))
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Ω(x == nil).ShouldNot(Equal(false))
+					Ω(nil == x).ShouldNot(Equal(false))
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).ShouldNot(Equal(false))
+					Ω(nil != y).ShouldNot(Equal(false))
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).ShouldNot(Equal(false))
+					Ω(nil == fNil()).ShouldNot(Equal(false))
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).ShouldNot(Equal(false))
+					Ω(nil != fNotNil()).ShouldNot(Equal(false))
+				})
+			})
+		})
+
+		Context("test NotTo", func() {
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Ω(x == nil).NotTo(BeFalse())
+					Ω(nil == x).NotTo(BeFalse())
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).NotTo(BeFalse())
+					Ω(nil != y).NotTo(BeFalse())
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).NotTo(BeFalse())
+					Ω(nil == fNil()).NotTo(BeFalse())
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).NotTo(BeFalse())
+					Ω(nil != fNotNil()).NotTo(BeFalse())
+				})
+			})
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Ω(x != nil).NotTo(BeTrue())
+					Ω(nil != x).NotTo(BeTrue())
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).NotTo(BeTrue())
+					Ω(nil == y).NotTo(BeTrue())
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).NotTo(BeTrue())
+					Ω(nil != fNil()).NotTo(BeTrue())
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).NotTo(BeTrue())
+					Ω(nil == fNotNil()).NotTo(BeTrue())
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Ω(x != nil).NotTo(Equal(true))
+					Ω(nil != x).NotTo(Equal(true))
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).NotTo(Equal(true))
+					Ω(nil == y).NotTo(Equal(true))
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).NotTo(Equal(true))
+					Ω(nil != fNil()).NotTo(Equal(true))
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).NotTo(Equal(true))
+					Ω(nil == fNotNil()).NotTo(Equal(true))
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Ω(x == nil).NotTo(Equal(false))
+					Ω(nil == x).NotTo(Equal(false))
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).NotTo(Equal(false))
+					Ω(nil != y).NotTo(Equal(false))
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).NotTo(Equal(false))
+					Ω(nil == fNil()).NotTo(Equal(false))
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).NotTo(Equal(false))
+					Ω(nil != fNotNil()).NotTo(Equal(false))
+				})
+			})
+		})
+		Context("test ToNot", func() {
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Ω(x == nil).ToNot(BeFalse())
+					Ω(nil == x).ToNot(BeFalse())
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).ToNot(BeFalse())
+					Ω(nil != y).ToNot(BeFalse())
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).ToNot(BeFalse())
+					Ω(nil == fNil()).ToNot(BeFalse())
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).ToNot(BeFalse())
+					Ω(nil != fNotNil()).ToNot(BeFalse())
+				})
+			})
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Ω(x != nil).ToNot(BeTrue())
+					Ω(nil != x).ToNot(BeTrue())
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).ToNot(BeTrue())
+					Ω(nil == y).ToNot(BeTrue())
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).ToNot(BeTrue())
+					Ω(nil != fNil()).ToNot(BeTrue())
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).ToNot(BeTrue())
+					Ω(nil == fNotNil()).ToNot(BeTrue())
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Ω(x != nil).ToNot(Equal(true))
+					Ω(nil != x).ToNot(Equal(true))
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).ToNot(Equal(true))
+					Ω(nil == y).ToNot(Equal(true))
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).ToNot(Equal(true))
+					Ω(nil != fNil()).ToNot(Equal(true))
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).ToNot(Equal(true))
+					Ω(nil == fNotNil()).ToNot(Equal(true))
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Ω(x == nil).ToNot(Equal(false))
+					Ω(nil == x).ToNot(Equal(false))
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).ToNot(Equal(false))
+					Ω(nil != y).ToNot(Equal(false))
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).ToNot(Equal(false))
+					Ω(nil == fNil()).ToNot(Equal(false))
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).ToNot(Equal(false))
+					Ω(nil != fNotNil()).ToNot(Equal(false))
+				})
+			})
+		})
+	})
+})

--- a/testdata/src/a/len/a.go
+++ b/testdata/src/a/len/a.go
@@ -1,4 +1,4 @@
-package a
+package len
 
 import (
 	. "github.com/onsi/ginkgo/v2"

--- a/testdata/src/a/nil/a.go
+++ b/testdata/src/a/nil/a.go
@@ -1,0 +1,1594 @@
+package nil
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func fNil() *string {
+	return nil
+}
+
+func fNotNil() *string {
+	val := "no nil"
+	return &val
+}
+
+var _ = Describe("", func() {
+
+	var x *int
+	val := 3
+	y := &val
+
+	Context("test Expect", func() {
+		Context("test Should", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Expect(x == nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+					Expect(nil == x).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil != y).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Expect(nil == fNil()).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil != fNotNil()).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Expect(x != nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+					Expect(nil != x).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil == y).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Expect(nil != fNil()).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil == fNotNil()).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Expect(x == nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+					Expect(nil == x).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil != y).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Expect(nil == fNil()).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil != fNotNil()).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Expect(x != nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+					Expect(nil != x).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil == y).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Expect(nil != fNil()).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil == fNotNil()).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+		})
+		Context("test Should(Not())", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Expect(x == nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+					Expect(nil == x).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil != y).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Expect(nil == fNil()).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil != fNotNil()).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Expect(x != nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+					Expect(nil != x).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil == y).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Expect(nil != fNil()).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil == fNotNil()).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Expect(x == nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+					Expect(nil == x).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil != y).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Expect(nil == fNil()).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil != fNotNil()).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Expect(x != nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+					Expect(nil != x).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil == y).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Expect(nil != fNil()).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil == fNotNil()).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+		})
+
+		Context("test To", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Expect(x == nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+					Expect(nil == x).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil != y).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Expect(nil == fNil()).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil != fNotNil()).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Expect(x != nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+					Expect(nil != x).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil == y).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Expect(nil != fNil()).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil == fNotNil()).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Expect(x == nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+					Expect(nil == x).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil != y).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Expect(nil == fNil()).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil != fNotNil()).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Expect(x != nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+					Expect(nil != x).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil == y).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Expect(nil != fNil()).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil == fNotNil()).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+		})
+		Context("test To(Not())", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Expect(x == nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+					Expect(nil == x).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil != y).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Expect(nil == fNil()).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil != fNotNil()).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Expect(x != nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+					Expect(nil != x).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil == y).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Expect(nil != fNil()).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil == fNotNil()).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Expect(x == nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+					Expect(nil == x).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil != y).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Expect(nil == fNil()).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil != fNotNil()).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Expect(x != nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+					Expect(nil != x).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil == y).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Expect(nil != fNil()).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil == fNotNil()).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+		})
+
+		Context("test ShouldNot", func() {
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Expect(x == nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+					Expect(nil == x).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil != y).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Expect(nil == fNil()).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil != fNotNil()).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Expect(x != nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+					Expect(nil != x).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil == y).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Expect(nil != fNil()).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil == fNotNil()).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Expect(x != nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+					Expect(nil != x).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil == y).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Expect(nil != fNil()).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil == fNotNil()).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Expect(x == nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+					Expect(nil == x).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil != y).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Expect(nil == fNil()).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Expect(nil != fNotNil()).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+		})
+
+		Context("test NotTo", func() {
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Expect(x == nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+					Expect(nil == x).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil != y).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Expect(nil == fNil()).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil != fNotNil()).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Expect(x != nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+					Expect(nil != x).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.NotTo\(beNil\(\)\). instead`
+					Expect(nil == y).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.NotTo\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Expect(nil != fNil()).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.NotTo\(beNil\(\)\). instead`
+					Expect(nil == fNotNil()).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.NotTo\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Expect(x != nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+					Expect(nil != x).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.NotTo\(beNil\(\)\). instead`
+					Expect(nil == y).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.NotTo\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Expect(nil != fNil()).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.NotTo\(beNil\(\)\). instead`
+					Expect(nil == fNotNil()).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.NotTo\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Expect(x == nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+					Expect(nil == x).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil != y).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Expect(nil == fNil()).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil != fNotNil()).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+		})
+		Context("test ToNot", func() {
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Expect(x == nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+					Expect(nil == x).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil != y).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Expect(nil == fNil()).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil != fNotNil()).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Expect(x != nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+					Expect(nil != x).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil == y).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Expect(nil != fNil()).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil == fNotNil()).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Expect(x != nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+					Expect(nil != x).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y == nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil == y).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() != nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Expect(nil != fNil()).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() == nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil == fNotNil()).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Expect(x == nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+					Expect(nil == x).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Expect(y != nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil != y).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Expect(fNil() == nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Expect(nil == fNil()).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Expect(fNotNil() != nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Expect(nil != fNotNil()).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+		})
+	})
+
+	Context("test ExpectWithOffset", func() {
+		Context("test Should", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+		})
+		Context("test Should(Not())", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+		})
+
+		Context("test To", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+		})
+		Context("test To(Not())", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+		})
+
+		Context("test ShouldNot", func() {
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+		})
+
+		Context("test NotTo", func() {
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.NotTo\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.NotTo\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.NotTo\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.NotTo\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.NotTo\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.NotTo\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.NotTo\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.NotTo\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+		})
+		Context("test ToNot", func() {
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x != nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y == nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() != nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() == nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					ExpectWithOffset(1, x == nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					ExpectWithOffset(1, y != nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					ExpectWithOffset(1, fNil() == nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					ExpectWithOffset(1, fNotNil() != nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+		})
+	})
+
+	Context("test Ω", func() {
+		Context("test Should", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Ω(x == nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+					Ω(nil == x).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil != y).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Ω(nil == fNil()).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil != fNotNil()).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Ω(x != nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+					Ω(nil != x).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil == y).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Ω(nil != fNil()).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil == fNotNil()).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Ω(x == nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+					Ω(nil == x).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil != y).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Ω(nil == fNil()).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil != fNotNil()).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Ω(x != nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+					Ω(nil != x).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil == y).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Ω(nil != fNil()).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil == fNotNil()).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+		})
+		Context("test Should(Not())", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Ω(x == nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+					Ω(nil == x).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil != y).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Ω(nil == fNil()).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil != fNotNil()).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Ω(x != nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+					Ω(nil != x).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil == y).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Ω(nil != fNil()).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil == fNotNil()).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Ω(x == nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+					Ω(nil == x).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil != y).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Ω(nil == fNil()).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil != fNotNil()).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Ω(x != nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+					Ω(nil != x).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil == y).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Ω(nil != fNil()).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil == fNotNil()).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+		})
+
+		Context("test To", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Ω(x == nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+					Ω(nil == x).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil != y).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Ω(nil == fNil()).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil != fNotNil()).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Ω(x != nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+					Ω(nil != x).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil == y).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Ω(nil != fNil()).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil == fNotNil()).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Ω(x == nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+					Ω(nil == x).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil != y).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Ω(nil == fNil()).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil != fNotNil()).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Ω(x != nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+					Ω(nil != x).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil == y).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Ω(nil != fNil()).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil == fNotNil()).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+		})
+		Context("test To(Not())", func() {
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Ω(x == nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+					Ω(nil == x).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil != y).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Ω(nil == fNil()).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil != fNotNil()).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Ω(x != nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+					Ω(nil != x).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil == y).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Ω(nil != fNil()).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil == fNotNil()).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Ω(x == nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+					Ω(nil == x).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil != y).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Ω(nil == fNil()).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil != fNotNil()).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Ω(x != nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+					Ω(nil != x).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil == y).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Ω(nil != fNil()).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil == fNotNil()).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+		})
+
+		Context("test ShouldNot", func() {
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Ω(x == nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+					Ω(nil == x).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil != y).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Ω(nil == fNil()).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil != fNotNil()).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Ω(x != nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+					Ω(nil != x).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil == y).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Ω(nil != fNil()).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil == fNotNil()).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Ω(x != nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+					Ω(nil != x).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil == y).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Ω(nil != fNil()).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil == fNotNil()).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Ω(x == nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+					Ω(nil == x).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil != y).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+					Ω(nil == fNil()).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+					Ω(nil != fNotNil()).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(beNil\(\)\). instead`
+				})
+			})
+		})
+
+		Context("test NotTo", func() {
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Ω(x == nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+					Ω(nil == x).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil != y).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Ω(nil == fNil()).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil != fNotNil()).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Ω(x != nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+					Ω(nil != x).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.NotTo\(beNil\(\)\). instead`
+					Ω(nil == y).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.NotTo\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Ω(nil != fNil()).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.NotTo\(beNil\(\)\). instead`
+					Ω(nil == fNotNil()).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.NotTo\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Ω(x != nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+					Ω(nil != x).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.NotTo\(beNil\(\)\). instead`
+					Ω(nil == y).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.NotTo\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Ω(nil != fNil()).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.NotTo\(beNil\(\)\). instead`
+					Ω(nil == fNotNil()).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.NotTo\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Ω(x == nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+					Ω(nil == x).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil != y).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Ω(nil == fNil()).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil != fNotNil()).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+		})
+		Context("test ToNot", func() {
+			Context("test BeFalse", func() {
+				It("test nil value", func() {
+					Ω(x == nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+					Ω(nil == x).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil != y).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Ω(nil == fNil()).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil != fNotNil()).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test BeTrue", func() {
+				It("test nil value", func() {
+					Ω(x != nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+					Ω(nil != x).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil == y).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Ω(nil != fNil()).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil == fNotNil()).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(true)", func() {
+				It("test nil value", func() {
+					Ω(x != nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+					Ω(nil != x).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y == nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil == y).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() != nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Ω(nil != fNil()).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() == nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil == fNotNil()).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+			Context("test Equal(false)", func() {
+				It("test nil value", func() {
+					Ω(x == nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+					Ω(nil == x).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil value", func() {
+					Ω(y != nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil != y).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(beNil\(\)\). instead`
+				})
+				It("test nil func", func() {
+					Ω(fNil() == nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+					Ω(nil == fNil()).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(beNil\(\)\). instead`
+				})
+				It("test non-nil func", func() {
+					Ω(fNotNil() != nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+					Ω(nil != fNotNil()).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(beNil\(\)\). instead`
+				})
+			})
+		})
+	})
+})

--- a/testdata/src/a/suppress/a.go
+++ b/testdata/src/a/suppress/a.go
@@ -1,4 +1,4 @@
-package a
+package suppress
 
 import (
 	. "github.com/onsi/ginkgo/v2"
@@ -27,6 +27,31 @@ var _ = Describe("Supress wrong length check", func() {
 				occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 			*/
 			Expect(len("abc")).Should(Equal(3))
+		})
+	})
+
+	Context("test ginkgo-linter:ignore-nil-assert-warning", func() {
+		var x *int
+		It("should ignore length warning", func() {
+			// ginkgo-linter:ignore-nil-assert-warning
+			Expect(x == nil).Should(BeTrue())
+			Expect(x == nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(beNil\(\)\). instead`
+			Expect(x).To(BeNil())
+			/*
+
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+				aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+				Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+				occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+				ginkgo-linter:ignore-nil-assert-warning
+
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+				aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+				Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+				occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+			*/
+			Expect(x == nil).Should(BeTrue())
 		})
 	})
 })

--- a/testdata/src/a/suppress/b.go
+++ b/testdata/src/a/suppress/b.go
@@ -1,4 +1,4 @@
-package a
+package suppress
 
 // ginkgo-linter:ignore-len-assert-warning
 

--- a/testdata/src/a/suppress/c.go
+++ b/testdata/src/a/suppress/c.go
@@ -1,4 +1,4 @@
-package a
+package suppress
 
 /*
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna

--- a/testdata/src/a/suppress/d.go
+++ b/testdata/src/a/suppress/d.go
@@ -1,0 +1,16 @@
+package suppress
+
+// ginkgo-linter:ignore-nil-assert-warning
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("suppress file", func() {
+	var x *int
+	It("should ignore nil warning", func() {
+		Expect(x == nil).Should(Equal(true))
+		Expect(x == nil).ShouldNot(BeTrue())
+	})
+})


### PR DESCRIPTION
*Add new warning when using these formats:
`Expect(x == nil).To(Equal(true))` => `Expect(x).To(BeNil())`
`Expect(x == nil).To(Equal(false))` => `Expect(x).ToNot(BeNil())`
`Expect(x == nil).To(BeTrue())` => `Expect(x).To(BeNil())`
`Expect(x == nil).To(BeFalse())` => `Expect(x).ToNot(BeNil())`

* Add two command line flags:
   * suppress-len-assertion - to suppress the wrong length assertion
     warning
   * suppress-nil-assertion - to suppress the wrong nil assertion
     warning
