### PR TITLE
Support different ways to import gomega

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -28,7 +28,7 @@ jobs:
       run: |-
         cp ginkgo-linter testdata/src/a
         cd testdata/src/a
-        [[ $(./ginkgo-linter ./... 2>&1 | wc -l) == 1946 ]]
-        [[ $(./ginkgo-linter --suppress-len-assertion=true ./... 2>&1 | wc -l) == 1345 ]]
-        [[ $(./ginkgo-linter --suppress-nil-assertion=true ./... 2>&1 | wc -l) == 601 ]]
+        [[ $(./ginkgo-linter ./... 2>&1 | wc -l) == 1964 ]]
+        [[ $(./ginkgo-linter --suppress-len-assertion=true ./... 2>&1 | wc -l) == 1350 ]]
+        [[ $(./ginkgo-linter --suppress-nil-assertion=true ./... 2>&1 | wc -l) == 614 ]]
         [[ $(./ginkgo-linter --suppress-nil-assertion=true --suppress-len-assertion=true ./... 2>&1 | wc -l) == 0 ]]

--- a/ginkgo_linter_test.go
+++ b/ginkgo_linter_test.go
@@ -68,3 +68,11 @@ func TestFlags_suppress_all(t *testing.T) {
 	a := analyzerFunc()
 	analysistest.Run(t, analysistest.TestData(), a, "a/configlen", "a/confignil")
 }
+
+func TestNoGinkgo(t *testing.T) {
+	analysistest.Run(t, analysistest.TestData(), ginkgolinter.NewAnalyzer(), "a/noginkgo")
+}
+
+func TestNoDotImport(t *testing.T) {
+	analysistest.Run(t, analysistest.TestData(), ginkgolinter.NewAnalyzer(), "a/nodotimport")
+}

--- a/testdata/src/a/nodotimport/a.go
+++ b/testdata/src/a/nodotimport/a.go
@@ -1,0 +1,27 @@
+package nodotimport
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("no dot import", func() {
+	ginkgo.It("should trigger length warning", func() {
+		const length = 3
+		gomega.Expect(len("abc")).Should(gomega.Equal(3))               // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.Should\(gomega\.HaveLen\(3\)\). instead`
+		gomega.Expect(len("abc")).Should(gomega.Not(gomega.Equal(4)))   // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.ShouldNot\(gomega\.HaveLen\(4\)\). instead`
+		gomega.Expect(len("abc")).Should(gomega.Equal(length))          // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.Should\(gomega\.HaveLen\(length\)\). instead`
+		gomega.Expect(len("")).Should(gomega.Equal(0))                  // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\(""\)\.Should\(gomega\.BeEmpty\(\)\). instead`
+		gomega.Expect(len("abc")).ShouldNot(gomega.BeZero())            // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.ShouldNot\(gomega\.BeEmpty\(\)\). instead`
+		gomega.Expect(len("abc")).Should(gomega.BeNumerically(">", 0))  // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.ShouldNot\(gomega\.BeEmpty\(\)\). instead`
+		gomega.Expect(len("abc")).Should(gomega.BeNumerically("==", 3)) // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.Should\(gomega\.HaveLen\(3\)\). instead`
+	})
+	ginkgo.It("should trigger nil warning", func() {
+		var x *int
+		gomega.Expect(x == nil).Should(gomega.Equal(true))           // want `ginkgo-linter: wrong nil assertion; consider using .gomega\.Expect\(x\)\.Should\(gomega\.beNil\(\)\). instead`
+		gomega.Expect(x == nil).ShouldNot(gomega.Equal(false))       // want `ginkgo-linter: wrong nil assertion; consider using .gomega\.Expect\(x\)\.Should\(gomega\.beNil\(\)\). instead`
+		gomega.Expect(nil == x).Should(gomega.BeTrue())              // want `ginkgo-linter: wrong nil assertion; consider using .gomega\.Expect\(x\)\.Should\(gomega\.beNil\(\)\). instead`
+		gomega.Expect(x == nil).ShouldNot(gomega.BeFalse())          // want `ginkgo-linter: wrong nil assertion; consider using .gomega\.Expect\(x\)\.Should\(gomega\.beNil\(\)\). instead`
+		gomega.Expect(x == nil).Should(gomega.Not(gomega.BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .gomega\.Expect\(x\)\.Should\(gomega\.beNil\(\)\). instead`
+	})
+})

--- a/testdata/src/a/nodotimport/b.go
+++ b/testdata/src/a/nodotimport/b.go
@@ -1,0 +1,18 @@
+package nodotimport
+
+import (
+	g1 "github.com/onsi/ginkgo/v2"
+	g2 "github.com/onsi/gomega"
+)
+
+var _ = g1.Describe("no dot import", func() {
+	g1.It("should ignore length warning", func() {
+		const length = 3
+		g2.Expect(len("abc")).Should(g2.Equal(3))               // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\("abc"\)\.Should\(g2\.HaveLen\(3\)\). instead`
+		g2.Expect(len("abc")).Should(g2.Equal(length))          // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\("abc"\)\.Should\(g2\.HaveLen\(length\)\). instead`
+		g2.Expect(len("")).Should(g2.Equal(0))                  // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\(""\)\.Should\(g2\.BeEmpty\(\)\). instead`
+		g2.Expect(len("abc")).ShouldNot(g2.BeZero())            // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\("abc"\)\.ShouldNot\(g2\.BeEmpty\(\)\). instead`
+		g2.Expect(len("abc")).Should(g2.BeNumerically(">", 0))  // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\("abc"\)\.ShouldNot\(g2\.BeEmpty\(\)\). instead`
+		g2.Expect(len("abc")).Should(g2.BeNumerically("==", 3)) // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\("abc"\).Should\(g2\.HaveLen\(3\)\). instead`
+	})
+})

--- a/testdata/src/a/noginkgo/a.go
+++ b/testdata/src/a/noginkgo/a.go
@@ -1,0 +1,23 @@
+package noginkgo
+
+// this test checks that files with no ginkgo import, does not trigger warning.
+// It mimics the gomega API, so the pattern should be the same.
+
+type fakeAssertion struct{}
+
+func (fakeAssertion) Should(_ bool) {
+
+}
+
+func Expect(i int) fakeAssertion {
+	return fakeAssertion{}
+}
+
+func Equal(_ int) bool {
+	return true
+}
+
+func test() {
+	x := []int{1, 2, 3, 4, 5}
+	Expect(len(x)).Should(Equal(5))
+}


### PR DESCRIPTION
ginkgo documentation uses dot import; i.e.
```go
import . "github.com/onsi/gomega"
```

But the user can use impot without name or with custom name, e.g.
```go
import "github.com/onsi/gomega"
```
Or
```go
import custom "github.com/onsi/gomega"
```

This PR adds support for these two forms of importt.

Also, the linter now skips files without gomega import.