### PR TITLE
Rename te executable

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -26,9 +26,9 @@ jobs:
     
     - name: Functional Test
       run: |-
-        cp ginkgo-linter testdata/src/a
+        cp ginkgolinter testdata/src/a
         cd testdata/src/a
-        [[ $(./ginkgo-linter ./... 2>&1 | wc -l) == 1969 ]]
-        [[ $(./ginkgo-linter --suppress-len-assertion=true ./... 2>&1 | wc -l) == 1355 ]]
-        [[ $(./ginkgo-linter --suppress-nil-assertion=true ./... 2>&1 | wc -l) == 614 ]]
-        [[ $(./ginkgo-linter --suppress-nil-assertion=true --suppress-len-assertion=true ./... 2>&1 | wc -l) == 0 ]]
+        [[ $(./ginkgolinter ./... 2>&1 | wc -l) == 1969 ]]
+        [[ $(./ginkgolinter --suppress-len-assertion=true ./... 2>&1 | wc -l) == 1355 ]]
+        [[ $(./ginkgolinter --suppress-nil-assertion=true ./... 2>&1 | wc -l) == 614 ]]
+        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true ./... 2>&1 | wc -l) == 0 ]]

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 build:
-	go build -o ginkgo-linter ./cmd/ginkgolinter
+	go build -o ginkgolinter ./cmd/ginkgolinter
 
 build-for-windows:
-	GOOS=windows GOARCH=amd64 go build -o bin/ginkgo-linter-amd64.exe ./cmd/ginkgolinter
+	GOOS=windows GOARCH=amd64 go build -o bin/ginkgolinter-amd64.exe ./cmd/ginkgolinter
 
 build-for-mac:
-	GOOS=darwin GOARCH=amd64 go build -o bin/ginkgo-linter-amd64-darwin ./cmd/ginkgolinter
+	GOOS=darwin GOARCH=amd64 go build -o bin/ginkgolinter-amd64-darwin ./cmd/ginkgolinter
 
 build-for-linux:
-	GOOS=linux GOARCH=amd64 go build -o bin/ginkgo-linter-amd64-linux ./cmd/ginkgolinter
-	GOOS=linux GOARCH=386 go build -o bin/ginkgo-linter-386-linux ./cmd/ginkgolinter
+	GOOS=linux GOARCH=amd64 go build -o bin/ginkgolinter-amd64-linux ./cmd/ginkgolinter
+	GOOS=linux GOARCH=386 go build -o bin/ginkgolinter-386-linux ./cmd/ginkgolinter
 
 build-all: build build-for-linux build-for-mac build-for-windows

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Then add the new executable to your PATH.
 
 ## usage
 ```shell
-ginkgo-linter [-fix] .
+ginkgolinter [-fix] ./...
 ```
 Use the `-fix` flag to apply the fix suggestions to the source code.
 


### PR DESCRIPTION
Some tools built ginkgo-linter and other ginkgolinter (because go does
not allow package names with '-').

Now the name is `ginkgolinter` from all the tools.