### PR TITLE
Support gomega without ginkgo

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -41,8 +41,8 @@ jobs:
         cp ginkgolinter testdata/src/a
         cd testdata/src/a
 
-        [[ $(./ginkgolinter ./... 2>&1 | wc -l) == 2074 ]]
+        [[ $(./ginkgolinter ./... 2>&1 | wc -l) == 2095 ]]
         [[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true ./... 2>&1 | wc -l) == 1363 ]]
-        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true ./... 2>&1 | wc -l) == 617 ]]
-        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true ./... 2>&1 | wc -l) == 100 ]]
+        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true ./... 2>&1 | wc -l) == 620 ]]
+        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true ./... 2>&1 | wc -l) == 118 ]]
         [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true ./... 2>&1 | wc -l) == 0 ]]

--- a/ginkgo_linter_test.go
+++ b/ginkgo_linter_test.go
@@ -107,3 +107,7 @@ func TestNoDotImport(t *testing.T) {
 func TestErrNil(t *testing.T) {
 	analysistest.Run(t, analysistest.TestData(), ginkgolinter.NewAnalyzer(), "a/errnil")
 }
+
+func TestGomegaOnly(t *testing.T) {
+	analysistest.Run(t, analysistest.TestData(), ginkgolinter.NewAnalyzer(), "a/gomegaonly")
+}

--- a/gomegahandler/handler.go
+++ b/gomegahandler/handler.go
@@ -1,6 +1,9 @@
 package gomegahandler
 
-import "go/ast"
+import (
+	"go/ast"
+	"go/token"
+)
 
 // Handler provide different handling, depend on the way gomega was imported, whether
 // in imported with "." name, custom name or without any name.
@@ -9,6 +12,10 @@ type Handler interface {
 	GetActualFuncName(*ast.CallExpr) (string, bool)
 	// ReplaceFunction replaces the function with another one, for fix suggestions
 	ReplaceFunction(*ast.CallExpr, *ast.Ident)
+
+	getDefFuncName(expr *ast.CallExpr) string
+
+	getFieldType(field *ast.Field) string
 }
 
 // GetGomegaHandler returns a gomegar handler according to the way gomega was imported in the specific file
@@ -36,18 +43,43 @@ func GetGomegaHandler(file *ast.File) Handler {
 type dotHandler struct{}
 
 // GetActualFuncName returns the name of the gomega function, e.g. `Expect`
-func (dotHandler) GetActualFuncName(expr *ast.CallExpr) (string, bool) {
-	actualFunc, ok := expr.Fun.(*ast.Ident)
-	if !ok {
-		return "", false
+func (h dotHandler) GetActualFuncName(expr *ast.CallExpr) (string, bool) {
+	switch actualFunc := expr.Fun.(type) {
+	case *ast.Ident:
+		return actualFunc.Name, true
+	case *ast.SelectorExpr:
+		if isGomegaVar(actualFunc.X, h) {
+			return actualFunc.Sel.Name, true
+		}
 	}
-
-	return actualFunc.Name, true
+	return "", false
 }
 
 // ReplaceFunction replaces the function with another one, for fix suggestions
 func (dotHandler) ReplaceFunction(caller *ast.CallExpr, newExpr *ast.Ident) {
 	caller.Fun = newExpr
+}
+
+func (dotHandler) getDefFuncName(expr *ast.CallExpr) string {
+	if f, ok := expr.Fun.(*ast.Ident); ok {
+		return f.Name
+	}
+	return ""
+}
+
+func (dotHandler) getFieldType(field *ast.Field) string {
+	switch t := field.Type.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.StarExpr:
+		if name, ok := t.X.(*ast.Ident); ok {
+			return name.Name
+		}
+	}
+	if id, ok := field.Type.(*ast.Ident); ok {
+		return id.Name
+	}
+	return ""
 }
 
 // nameHandler is used when importing gomega without name; i.e.
@@ -70,7 +102,9 @@ func (g nameHandler) GetActualFuncName(expr *ast.CallExpr) (string, bool) {
 	}
 
 	if x.Name != string(g) {
-		return "", false
+		if !isGomegaVar(x, g) {
+			return "", false
+		}
 	}
 
 	return selector.Sel.Name, true
@@ -79,4 +113,58 @@ func (g nameHandler) GetActualFuncName(expr *ast.CallExpr) (string, bool) {
 // ReplaceFunction replaces the function with another one, for fix suggestions
 func (nameHandler) ReplaceFunction(caller *ast.CallExpr, newExpr *ast.Ident) {
 	caller.Fun.(*ast.SelectorExpr).Sel = newExpr
+}
+
+func (g nameHandler) getDefFuncName(expr *ast.CallExpr) string {
+	if sel, ok := expr.Fun.(*ast.SelectorExpr); ok {
+		if f, ok := sel.X.(*ast.Ident); ok && f.Name == string(g) {
+			return sel.Sel.Name
+		}
+	}
+	return ""
+}
+
+func (g nameHandler) getFieldType(field *ast.Field) string {
+	switch t := field.Type.(type) {
+	case *ast.SelectorExpr:
+		if id, ok := t.X.(*ast.Ident); ok {
+			if id.Name == string(g) {
+				return t.Sel.Name
+			}
+		}
+	case *ast.StarExpr:
+		if sel, ok := t.X.(*ast.SelectorExpr); ok {
+			if x, ok := sel.X.(*ast.Ident); ok && x.Name == string(g) {
+				return sel.Sel.Name
+			}
+		}
+
+	}
+	return ""
+}
+
+func isGomegaVar(x ast.Expr, handler Handler) bool {
+	if i, ok := x.(*ast.Ident); ok {
+		if i.Obj != nil && i.Obj.Kind == ast.Var {
+			switch decl := i.Obj.Decl.(type) {
+			case *ast.AssignStmt:
+				if decl.Tok == token.DEFINE {
+					if defFunc, ok := decl.Rhs[0].(*ast.CallExpr); ok {
+						fName := handler.getDefFuncName(defFunc)
+						switch fName {
+						case "NewGomega", "NewWithT", "NewGomegaWithT":
+							return true
+						}
+					}
+				}
+			case *ast.Field:
+				name := handler.getFieldType(decl)
+				switch name {
+				case "Gomega", "WithT", "GomegaWithT":
+					return true
+				}
+			}
+		}
+	}
+	return false
 }

--- a/testdata/src/a/gomegaonly/gomegaonly_test.go
+++ b/testdata/src/a/gomegaonly/gomegaonly_test.go
@@ -1,0 +1,54 @@
+package gomegaonly
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGomegaOnly_NewGomegaWithT(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var err error
+	g.Expect(err).ToNot(BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.To\(HaveOccurred\(\)\). instead`
+	assert(g, err)
+	assertWithT(g, err)
+	assertGomegaWithT(g, err)
+}
+
+func assert(g Gomega, err error) {
+	g.Expect(err).To(BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
+}
+
+func assertWithT(g *WithT, err error) {
+	g.Expect(err).To(BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
+}
+
+func assertGomegaWithT(g *GomegaWithT, err error) {
+	g.Expect(err).To(BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
+}
+
+func TestGomegaOnly_NewWithT(t *testing.T) {
+	g := NewWithT(t)
+
+	var err error
+	g.Expect(err).ToNot(BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.To\(HaveOccurred\(\)\). instead`
+	assert(g, err)
+}
+
+func TestGomegaOnly_NewGomega(t *testing.T) {
+	g := NewGomega(Fail)
+
+	var err error
+	g.Expect(err).ToNot(BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.To\(HaveOccurred\(\)\). instead`
+	assert(g, err)
+}
+
+var _ = Describe("check gomega parameter", func() {
+	Eventually(func(g Gomega) error {
+		arr := []int{1, 2, 3}
+		g.Expect(len(arr)).Should(Equal(3)) // want `ginkgo-linter: wrong length assertion; consider using .g\.Expect\(arr\)\.Should\(HaveLen\(3\)\). instead`
+		return nil
+	}).Should(Succeed())
+})

--- a/testdata/src/a/gomegaonly/gomegaonly_w_mod_name_test.go
+++ b/testdata/src/a/gomegaonly/gomegaonly_w_mod_name_test.go
@@ -1,0 +1,53 @@
+package gomegaonly
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	gom "github.com/onsi/gomega"
+)
+
+func TestGomegaOnlyWithModName_NewGomegaWithT(t *testing.T) {
+	g := gom.NewGomegaWithT(t)
+
+	var err error
+	g.Expect(err).ToNot(gom.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.To\(gom.HaveOccurred\(\)\). instead`
+
+	assertWithModName(g, err)
+	assertWithNameModWithT(g, err)
+	assertWithModNameGomegaWithT(g, err)
+}
+
+func TestGomegaOnlyWithModName_NewWithT(t *testing.T) {
+	g := gom.NewWithT(t)
+
+	var err error
+	g.Expect(err).ToNot(gom.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.To\(gom.HaveOccurred\(\)\). instead`
+}
+
+func TestGomegaOnlyWithModName_NewGomega(t *testing.T) {
+	g := gom.NewGomega(Fail)
+
+	var err error
+	g.Expect(err).ToNot(gom.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.To\(gom.HaveOccurred\(\)\). instead`
+}
+
+func assertWithModName(g gom.Gomega, err error) {
+	g.Expect(err).To(gom.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.ToNot\(gom\.HaveOccurred\(\)\). instead`
+}
+
+func assertWithNameModWithT(g *gom.WithT, err error) {
+	g.Expect(err).To(gom.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.ToNot\(gom\.HaveOccurred\(\)\). instead`
+}
+
+func assertWithModNameGomegaWithT(g *gom.WithT, err error) {
+	g.Expect(err).To(gom.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.ToNot\(gom\.HaveOccurred\(\)\). instead`
+}
+
+var _ = Describe("check gomega parameter", func() {
+	gom.Eventually(func(g gom.Gomega) error {
+		arr := []int{1, 2, 3}
+		g.Expect(len(arr)).Should(gom.Equal(3)) // want `ginkgo-linter: wrong length assertion; consider using .g\.Expect\(arr\)\.Should\(gom\.HaveLen\(3\)\). instead`
+		return nil
+	}).Should(gom.Succeed())
+})

--- a/testdata/src/a/gomegaonly/gomegaonly_w_name_test.go
+++ b/testdata/src/a/gomegaonly/gomegaonly_w_name_test.go
@@ -1,0 +1,53 @@
+package gomegaonly
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+func TestGomegaOnlyWithName_NewGomegaWithT(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	var err error
+	g.Expect(err).ToNot(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.To\(gomega.HaveOccurred\(\)\). instead`
+
+	assertWithName(g, err)
+	assertWithNameWithT(g, err)
+	assertWithNameGomegaWithT(g, err)
+}
+
+func TestGomegaOnlyWithName_NewWithT(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	var err error
+	g.Expect(err).ToNot(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.To\(gomega.HaveOccurred\(\)\). instead`
+}
+
+func TestGomegaOnlyWithName_NewGomega(t *testing.T) {
+	g := gomega.NewGomega(Fail)
+
+	var err error
+	g.Expect(err).ToNot(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.To\(gomega.HaveOccurred\(\)\). instead`
+}
+
+func assertWithName(g gomega.Gomega, err error) {
+	g.Expect(err).To(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.ToNot\(gomega\.HaveOccurred\(\)\). instead`
+}
+
+func assertWithNameWithT(g *gomega.WithT, err error) {
+	g.Expect(err).To(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.ToNot\(gomega\.HaveOccurred\(\)\). instead`
+}
+
+func assertWithNameGomegaWithT(g *gomega.WithT, err error) {
+	g.Expect(err).To(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.ToNot\(gomega\.HaveOccurred\(\)\). instead`
+}
+
+var _ = Describe("check gomega parameter", func() {
+	gomega.Eventually(func(g gomega.Gomega) error {
+		arr := []int{1, 2, 3}
+		g.Expect(len(arr)).Should(gomega.Equal(3)) // want `ginkgo-linter: wrong length assertion; consider using .g\.Expect\(arr\)\.Should\(gomega\.HaveLen\(3\)\). instead`
+		return nil
+	}).Should(gomega.Succeed())
+})


### PR DESCRIPTION
This PR adds support for cases when using gomega directly, without ginkgo.

For example:
```golang
func TestSomething(t *testing.T) {
    g := NewGomegaWithT(t)

    var err error
    g.Expect(err).ToNot(BeNil())
}
```