### PR TITLE
Fix bug where ginkgolinter fails other linters

### DIFF
--- a/ginkgo_linter.go
+++ b/ginkgo_linter.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-
 	"go/ast"
 	"go/printer"
 	"go/token"
 	gotypes "go/types"
 
+	"github.com/go-toolsmith/astcopy"
 	"golang.org/x/tools/go/analysis"
 
 	"github.com/nunnatsa/ginkgolinter/gomegahandler"
@@ -161,6 +161,7 @@ func (l *ginkgoLinter) run(pass *analysis.Pass) (interface{}, error) {
 }
 
 func checkExpression(pass *analysis.Pass, exprSuppress types.Suppress, actualArg ast.Expr, assertionExp *ast.CallExpr, handler gomegahandler.Handler) bool {
+	assertionExp = astcopy.CallExpr(assertionExp)
 	oldExpr := goFmt(pass.Fset, assertionExp)
 	if !bool(exprSuppress.Len) && isActualIsLenFunc(actualArg) {
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.19
 require golang.org/x/tools v0.1.11
 
 require (
+	github.com/go-toolsmith/astcopy v1.0.2 // indirect
+	golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/sys v0.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,9 @@
+github.com/go-toolsmith/astcopy v1.0.2 h1:YnWf5Rnh1hUudj11kei53kI57quN/VH6Hp1n+erozn0=
+github.com/go-toolsmith/astcopy v1.0.2/go.mod h1:4TcEdbElGc9twQEYpVo/aieIXfHhiuLh4aLAck6dO7Y=
+github.com/go-toolsmith/astequal v1.0.2/go.mod h1:9Ai4UglvtR+4up+bAD4+hCj7iTo4m/OXVTSLnCyTAx4=
+github.com/go-toolsmith/strparse v1.0.0/go.mod h1:YI2nUKP9YGZnL/L1/DLFBfixrcjslWct4wyljWhSRy8=
+golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171 h1:DZhP7zSquENyG3Yb6ZpGqNEtgE8dfXhcLcheIF9RQHY=
+golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=


### PR DESCRIPTION
ginkgolinter no longer write to the ast tree, and should not fails other linters anymore. Instead, it computes the suggested fixes using a clone, from the `github.com/go-toolsmith/astcopy` package

Fixes #39 