### PR TITLE
Add check HaveLen(0)

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -41,8 +41,9 @@ jobs:
         cp ginkgolinter testdata/src/a
         cd testdata/src/a
 
-        [[ $(./ginkgolinter ./... 2>&1 | wc -l) == 2095 ]]
-        [[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true ./... 2>&1 | wc -l) == 1363 ]]
-        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true ./... 2>&1 | wc -l) == 620 ]]
-        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true ./... 2>&1 | wc -l) == 118 ]]
+        [[ $(./ginkgolinter ./... 2>&1 | wc -l) == 2103 ]]
+        [[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true ./... 2>&1 | wc -l) == 1371 ]]
+        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true ./... 2>&1 | wc -l) == 628 ]]
+        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true ./... 2>&1 | wc -l) == 126 ]]
+        [[ $(./ginkgolinter --allow-havelen-0=true ./... 2>&1 | wc -l) == 2095 ]]
         [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true ./... 2>&1 | wc -l) == 0 ]]

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ The output of the linter,when finding issues, looks like this:
 ./testdata/src/a/a.go:18:5: ginkgo-linter: wrong length assertion; consider using `Expect("").Should(BeEmpty())` instead
 ./testdata/src/a/a.go:22:5: ginkgo-linter: wrong length assertion; consider using `Expect("").Should(BeEmpty())` instead
 ```
+#### use the `HaveLen(0)` matcher. 
+The linter will also warn about the `HaveLen(0)` matcher, and will suggest to replace it with `BeEmpty()`
 
 ### Wrong `nil` Assertion
 The linter finds assertion of the comparison to nil, with all kind of matchers, instead of using the existing `BeNil()` matcher; We want to assert the item, rather than a comparison result.
@@ -137,7 +139,7 @@ Expect(x).To(Equal(false)) // should be: Expect(x).To(BeFalse())
 ```
 It also supports the embedded `Not()` matcher; e.g.
 
-`Ω(x).Should(Not(Equal(True)))` => `Ω(x).ShouldNot(BeBeTrue())`
+`Ω(x).Should(Not(Equal(True)))` => `Ω(x).ShouldNot(BeTrue())`
 
 ### Wrong Error Assertion
 The linter finds assertion of errors compared with nil, or to be equal nil, or to be nil. The linter suggests to use `Succeed` for functions or `HaveOccurred` for error values..
@@ -162,6 +164,8 @@ It also supports the embedded `Not()` matcher; e.g.
 * Use the `--suppress-len-assertion=true` flag to suppress the wrong length assertion warning
 * Use the `--suppress-nil-assertion=true` flag to suppress the wrong nil assertion warning
 * Use the `--suppress-err-assertion=true` flag to suppress the wrong error assertion warning
+* Use the `--allow-havelen-0=true` flag to avoid warnings about `HaveLen(0)`; Note: this parameter is only supported from
+  command line, and not from a comment.
 
 ### Suppress warning from the code
 To suppress the wrong length assertion warning, add a comment with (only)

--- a/ginkgo_linter_test.go
+++ b/ginkgo_linter_test.go
@@ -13,6 +13,10 @@ func TestGinkgoLenLinter(t *testing.T) {
 	analysistest.Run(t, analysistest.TestData(), ginkgolinter.NewAnalyzer(), "a/len")
 }
 
+func TestGinkgoHaveLen0Linter(t *testing.T) {
+	analysistest.Run(t, analysistest.TestData(), ginkgolinter.NewAnalyzer(), "a/havelen0")
+}
+
 func TestGinkgoNilLinter(t *testing.T) {
 	analysistest.Run(t, analysistest.TestData(), ginkgolinter.NewAnalyzer(), "a/nil")
 }
@@ -26,7 +30,7 @@ func TestGinkgoEqualBooleanLinter(t *testing.T) {
 }
 
 func TestSuppress(t *testing.T) {
-	analysistest.Run(t, analysistest.TestData(), ginkgolinter.NewAnalyzer(), "a/suppress")
+	analysistest.Run(t, analysistest.TestData(), ginkgolinter.NewAnalyzer(), "a/config")
 }
 
 func TestFlags_suppress_len(t *testing.T) {
@@ -41,6 +45,20 @@ func TestFlags_suppress_len(t *testing.T) {
 
 	a := analyzerFunc()
 	analysistest.Run(t, analysistest.TestData(), a, "a/configlen")
+}
+
+func TestFlags_allowHaveLen0(t *testing.T) {
+	analyzerFunc := func() *analysis.Analyzer {
+		a := ginkgolinter.NewAnalyzer()
+		err := a.Flags.Set("allow-havelen-0", "true")
+		if err != nil {
+			t.Error(err)
+		}
+		return a
+	}
+
+	a := analyzerFunc()
+	analysistest.Run(t, analysistest.TestData(), a, "a/havelen0config")
 }
 
 func TestFlags_suppress_nil(t *testing.T) {

--- a/testdata/src/a/havelen0/gomega.go
+++ b/testdata/src/a/havelen0/gomega.go
@@ -1,0 +1,17 @@
+package havelen0
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestHaveLen0(t *testing.T) {
+	g := NewWithT(t)
+
+	x := make([]int, 0)
+	g.Expect(x).Should(HaveLen(0)) // want `ginkgo-linter: wrong length assertion; consider using .g\.Expect\(x\)\.Should\(BeEmpty\(\)\). instead`
+
+	x = append(x, 1)
+	g.Expect(x).Should(Not(HaveLen(0))) // want `ginkgo-linter: wrong length assertion; consider using .g\.Expect\(x\)\.ShouldNot\(BeEmpty\(\)\). instead`
+}

--- a/testdata/src/a/havelen0/havelen0.go
+++ b/testdata/src/a/havelen0/havelen0.go
@@ -1,0 +1,18 @@
+package havelen0
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const EMPTY = 0
+
+var _ = Describe("test HaveLen(0)", func() {
+	It("should replace HaveLen(0) with BeEmpty()", func() {
+		x := make([]int, 0)
+		Expect(x).To(HaveLen(0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(x\)\.To\(BeEmpty\(\)\). instead`
+
+		x = append(x, 1)
+		Expect(x).To(Not(HaveLen(0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(x\)\.ToNot\(BeEmpty\(\)\). instead`
+	})
+})

--- a/testdata/src/a/havelen0config/gomega.go
+++ b/testdata/src/a/havelen0config/gomega.go
@@ -1,0 +1,17 @@
+package havelen0
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestHaveLen0(t *testing.T) {
+	g := NewWithT(t)
+
+	x := make([]int, 0)
+	g.Expect(x).Should(HaveLen(0))
+
+	x = append(x, 1)
+	g.Expect(x).Should(Not(HaveLen(0)))
+}

--- a/testdata/src/a/havelen0config/havelen0.go
+++ b/testdata/src/a/havelen0config/havelen0.go
@@ -1,0 +1,18 @@
+package havelen0
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const EMPTY = 0
+
+var _ = Describe("test HaveLen(0)", func() {
+	It("should replace HaveLen(0) with BeEmpty()", func() {
+		x := make([]int, 0)
+		Expect(x).To(HaveLen(0))
+
+		x = append(x, 1)
+		Expect(x).To(Not(HaveLen(0)))
+	})
+})

--- a/types/boolean_test.go
+++ b/types/boolean_test.go
@@ -75,7 +75,7 @@ func TestBoolean_Set_nil(t *testing.T) {
 }
 
 func TestBoolean_String(t *testing.T) {
-	if val := Boolean(true).String(); val != "true" {
+	if val := (Boolean(true)).String(); val != "true" {
 		t.Errorf("Boolean(true).String() should return `true`, but it's %s", val)
 	}
 

--- a/types/config.go
+++ b/types/config.go
@@ -13,25 +13,27 @@ const (
 	suppressErrAssertionWarning    = suppressPrefix + "ignore-err-assert-warning"
 )
 
-type Suppress struct {
-	Len Boolean
-	Nil Boolean
-	Err Boolean
+type Config struct {
+	SuppressLen   Boolean
+	SuppressNil   Boolean
+	SuppressErr   Boolean
+	AllowHaveLen0 Boolean
 }
 
-func (s Suppress) AllTrue() bool {
-	return bool(s.Len && s.Nil && s.Err)
+func (s *Config) AllTrue() bool {
+	return bool(s.SuppressLen && s.SuppressNil && s.SuppressErr)
 }
 
-func (s Suppress) Clone() Suppress {
-	return Suppress{
-		Len: s.Len,
-		Nil: s.Nil,
-		Err: s.Err,
+func (s *Config) Clone() Config {
+	return Config{
+		SuppressLen:   s.SuppressLen,
+		SuppressNil:   s.SuppressNil,
+		SuppressErr:   s.SuppressErr,
+		AllowHaveLen0: s.AllowHaveLen0,
 	}
 }
 
-func (s *Suppress) UpdateFromComment(commentGroup []*ast.CommentGroup) {
+func (s *Config) UpdateFromComment(commentGroup []*ast.CommentGroup) {
 	for _, cmntList := range commentGroup {
 		if s.AllTrue() {
 			break
@@ -45,15 +47,15 @@ func (s *Suppress) UpdateFromComment(commentGroup []*ast.CommentGroup) {
 				comment = strings.TrimSuffix(comment, "*/")
 				comment = strings.TrimSpace(comment)
 
-				s.Len = s.Len || (comment == suppressLengthAssertionWarning)
-				s.Nil = s.Nil || (comment == suppressNilAssertionWarning)
-				s.Err = s.Err || (comment == suppressErrAssertionWarning)
+				s.SuppressLen = s.SuppressLen || (comment == suppressLengthAssertionWarning)
+				s.SuppressNil = s.SuppressNil || (comment == suppressNilAssertionWarning)
+				s.SuppressErr = s.SuppressErr || (comment == suppressErrAssertionWarning)
 			}
 		}
 	}
 }
 
-func (s *Suppress) UpdateFromFile(cm ast.CommentMap) {
+func (s *Config) UpdateFromFile(cm ast.CommentMap) {
 
 	for key, commentGroup := range cm {
 		if s.AllTrue() {

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -5,47 +5,47 @@ import (
 )
 
 func TestSuppress_AllTrue(t *testing.T) {
-	s := Suppress{
-		Len: true,
-		Nil: true,
-		Err: true,
+	s := Config{
+		SuppressLen: true,
+		SuppressNil: true,
+		SuppressErr: true,
 	}
 
 	if !s.AllTrue() {
 		t.Error("should be AllTrue")
 	}
 
-	s.Nil = false
+	s.SuppressNil = false
 	if s.AllTrue() {
 		t.Error("should not be AllTrue")
 	}
 
-	s.Len = false
+	s.SuppressLen = false
 	if s.AllTrue() {
 		t.Error("should not be AllTrue")
 	}
 
-	s.Nil = true
+	s.SuppressNil = true
 	if s.AllTrue() {
 		t.Error("should not be AllTrue")
 	}
 
-	s.Len = true
+	s.SuppressLen = true
 	if !s.AllTrue() {
 		t.Error("should be AllTrue")
 	}
 
-	s.Err = false
+	s.SuppressErr = false
 	if s.AllTrue() {
 		t.Error("should not be AllTrue")
 	}
 }
 
 func TestSuppress_Clone(t *testing.T) {
-	s := Suppress{
-		Len: true,
-		Nil: true,
-		Err: true,
+	s := Config{
+		SuppressLen: true,
+		SuppressNil: true,
+		SuppressErr: true,
 	}
 
 	clone := s.Clone()
@@ -53,17 +53,17 @@ func TestSuppress_Clone(t *testing.T) {
 		t.Error("should be AllTrue")
 	}
 
-	s.Len = false
-	s.Err = false
+	s.SuppressLen = false
+	s.SuppressErr = false
 
 	clone = s.Clone()
-	if clone.Len {
-		t.Error("s.Len should be false")
+	if clone.SuppressLen {
+		t.Error("s.SuppressLen should be false")
 	}
-	if !clone.Nil {
-		t.Error("s.Nil should be true")
+	if !clone.SuppressNil {
+		t.Error("s.SuppressNil should be true")
 	}
-	if clone.Err {
-		t.Error("s.Err should be false")
+	if clone.SuppressErr {
+		t.Error("s.SuppressErr should be false")
 	}
 }


### PR DESCRIPTION
The linter now warns for `HaveLen(0)`, and suggests using `BeEmpty()` instead

Support new parameter: `allow-havelen-0`. Default is false. If true, the linter will not warn for `HaveLen(0)`.

Fixes #46