### PR TITLE
Move to parameterized tests

### DIFF
--- a/testdata/src/a/noginkgo/a.go
+++ b/testdata/src/a/noginkgo/a.go
@@ -6,10 +6,10 @@ package noginkgo
 type fakeAssertion struct{}
 
 func (fakeAssertion) Should(_ bool) {
-
+	// no implementation
 }
 
-func Expect(i int) fakeAssertion {
+func Expect(_ int) fakeAssertion {
 	return fakeAssertion{}
 }
 


### PR DESCRIPTION
To ease addition of new features and tests, move the ginkgolinter tests to be parameterized tests.