### PR TITLE
Add new rule: don't use `fmt.Sprintf` for assertion description

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -41,9 +41,10 @@ jobs:
         cp ginkgolinter testdata/src/a
         cd testdata/src/a
 
-        [[ $(./ginkgolinter ./... 2>&1 | wc -l) == 2103 ]]
-        [[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true ./... 2>&1 | wc -l) == 1371 ]]
-        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true ./... 2>&1 | wc -l) == 628 ]]
-        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true ./... 2>&1 | wc -l) == 126 ]]
-        [[ $(./ginkgolinter --allow-havelen-0=true ./... 2>&1 | wc -l) == 2095 ]]
-        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true ./... 2>&1 | wc -l) == 0 ]]
+        [[ $(./ginkgolinter ./... 2>&1 | grep "ginkgo-linter:" | wc -l) == 2110 ]]
+        [[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true ./... 2>&1 | grep "ginkgo-linter:" | wc -l) == 1373 ]]
+        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true ./... 2>&1 | grep "ginkgo-linter:" | wc -l) == 631 ]]
+        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true ./... 2>&1 | grep "ginkgo-linter:" | wc -l) == 128 ]]
+        [[ $(./ginkgolinter --allow-havelen-0=true ./... 2>&1 | grep "ginkgo-linter:" | wc -l) == 2102 ]]
+        [[ $(./ginkgolinter --allow-sprintf=false ./... 2>&1 | grep "ginkgo-linter:" | wc -l) == 2114 ]]
+        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true ./... 2>&1 | grep "ginkgo-linter:" | wc -l) == 0 ]]

--- a/ginkgo_linter_test.go
+++ b/ginkgo_linter_test.go
@@ -64,38 +64,47 @@ func TestFlags(t *testing.T) {
 	for _, tc := range []struct {
 		testName string
 		testData []string
-		flags    []string
+		flags    map[string]string
 	}{
 		{
 			testName: "test the suppress-len-assertion flag",
 			testData: []string{"a/configlen"},
-			flags:    []string{"suppress-len-assertion"},
+			flags:    map[string]string{"suppress-len-assertion": "true"},
 		},
 		{
 			testName: "test the suppress-nil-assertion flag",
 			testData: []string{"a/confignil"},
-			flags:    []string{"suppress-nil-assertion"},
+			flags:    map[string]string{"suppress-nil-assertion": "true"},
 		},
 		{
 			testName: "test the suppress-err-assertion flag",
 			testData: []string{"a/configerr"},
-			flags:    []string{"suppress-err-assertion"},
+			flags:    map[string]string{"suppress-err-assertion": "true"},
 		},
 		{
 			testName: "test the allow-havelen-0 flag",
 			testData: []string{"a/havelen0config"},
-			flags:    []string{"allow-havelen-0"},
+			flags:    map[string]string{"allow-havelen-0": "true"},
+		},
+		{
+			testName: "check Springf message",
+			testData: []string{"a/sprintfmsg"},
+			flags:    map[string]string{"allow-sprintf": "false"},
 		},
 		{
 			testName: "supress all",
 			testData: []string{"a/configlen", "a/confignil", "a/configerr", "a/havelen0config"},
-			flags:    []string{"suppress-len-assertion", "suppress-nil-assertion", "suppress-err-assertion"},
+			flags: map[string]string{
+				"suppress-len-assertion": "true",
+				"suppress-nil-assertion": "true",
+				"suppress-err-assertion": "true",
+			},
 		},
 	} {
 		t.Run(tc.testName, func(tt *testing.T) {
 			analyzer := ginkgolinter.NewAnalyzer()
-			for _, flag := range tc.flags {
-				err := analyzer.Flags.Set(flag, "true")
+			for flag, value := range tc.flags {
+				err := analyzer.Flags.Set(flag, value)
 				if err != nil {
 					tt.Errorf(`failed to set the "%s" flag; %v`, flag, err)
 					return

--- a/sprintfchecker/sprintfchecker.go
+++ b/sprintfchecker/sprintfchecker.go
@@ -1,0 +1,51 @@
+package sprintfchecker
+
+import (
+	"go/ast"
+	"go/token"
+)
+
+type Checker struct {
+	importName string
+}
+
+func NewSprintfChecker(file *ast.File) *Checker {
+	for _, imp := range file.Imports {
+		if imp.Path.Kind == token.STRING && imp.Path.Value == `"fmt"` {
+			name := "fmt"
+			if imp.Name != nil {
+				name = imp.Name.Name
+			}
+
+			return &Checker{
+				importName: name,
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Checker) Check(assertionExp *ast.CallExpr) bool {
+	if s == nil {
+		return false
+	}
+
+	if len(assertionExp.Args) != 2 {
+		return false
+	}
+
+	if call, ok := assertionExp.Args[1].(*ast.CallExpr); ok {
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
+			if ident, ok := sel.X.(*ast.Ident); ok && ident.Name == s.importName && sel.Sel.Name == "Sprintf" {
+				args := make([]ast.Expr, len(call.Args)+1)
+				args[0] = assertionExp.Args[0]
+				copy(args[1:], call.Args)
+				assertionExp.Args = args
+
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/testdata/src/a/boolean/bool.go
+++ b/testdata/src/a/boolean/bool.go
@@ -9,8 +9,8 @@ var _ = Describe("Equal(true/false)", func() {
 	It("check Equal(true/false)", func() {
 		t := true
 		f := false
-		Expect(t).To(Equal(true))                        // want `ginkgo-linter: wrong boolean assertion; consider using .Expect\(t\)\.To\(BeTrue\(\)\). instead`
-		Expect(f).To(Equal(false))                       // want `ginkgo-linter: wrong boolean assertion; consider using .Expect\(f\)\.To\(BeFalse\(\)\). instead`
-		ExpectWithOffset(2, t).Should(Not(Equal(false))) // want `ginkgo-linter: wrong boolean assertion; consider using .ExpectWithOffset\(2, t\)\.ShouldNot\(BeFalse\(\)\). instead`
+		Expect(t).To(Equal(true))                        // want `ginkgo-linter: wrong boolean assertion\nconsider using .Expect\(t\)\.To\(BeTrue\(\)\). instead`
+		Expect(f).To(Equal(false))                       // want `ginkgo-linter: wrong boolean assertion\nconsider using .Expect\(f\)\.To\(BeFalse\(\)\). instead`
+		ExpectWithOffset(2, t).Should(Not(Equal(false))) // want `ginkgo-linter: wrong boolean assertion\nconsider using .ExpectWithOffset\(2, t\)\.ShouldNot\(BeFalse\(\)\). instead`
 	})
 })

--- a/testdata/src/a/equalnil/a.go
+++ b/testdata/src/a/equalnil/a.go
@@ -10,8 +10,8 @@ var _ = Describe("Check Equal(nil)", func() {
 		var x *int
 		var y = 5
 		var py = &y
-		Expect(x).Should(Equal(nil))                    // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
-		Expect(py).Should(Not(Equal(nil)))              // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(py\)\.ShouldNot\(BeNil\(\)\). instead`
-		ExpectWithOffset(1, py).Should(Not(Equal(nil))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, py\)\.ShouldNot\(BeNil\(\)\). instead`
+		Expect(x).Should(Equal(nil))                    // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+		Expect(py).Should(Not(Equal(nil)))              // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(py\)\.ShouldNot\(BeNil\(\)\). instead`
+		ExpectWithOffset(1, py).Should(Not(Equal(nil))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, py\)\.ShouldNot\(BeNil\(\)\). instead`
 	})
 })

--- a/testdata/src/a/errnil/a.go
+++ b/testdata/src/a/errnil/a.go
@@ -41,54 +41,54 @@ var _ = Describe("check Expect(err).To(BeNil())", func() {
 	tt := t{}
 
 	It("check Expect(err).To(BeNil())", func() {
-		Expect(errors.New("fake error")).To(Equal(nil)) // want `ginkgo-linter: wrong error assertion; consider using .Expect\(errors\.New\("fake error"\)\)\.To\(Succeed\(\)\). instead`
-		Expect(err).To(BeNil())                         // want `ginkgo-linter: wrong error assertion; consider using .Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
-		ExpectWithOffset(1, err).To(BeNil())            // want `ginkgo-linter: wrong error assertion; consider using .ExpectWithOffset\(1, err\)\.ToNot\(HaveOccurred\(\)\). instead`
-		Expect(err).To(Not(BeNil()))                    // want `ginkgo-linter: wrong error assertion; consider using .Expect\(err\)\.To\(HaveOccurred\(\)\). instead`
-		Expect(err).ToNot(BeNil())                      // want `ginkgo-linter: wrong error assertion; consider using .Expect\(err\)\.To\(HaveOccurred\(\)\). instead`
+		Expect(errors.New("fake error")).To(Equal(nil)) // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(errors\.New\("fake error"\)\)\.To\(Succeed\(\)\). instead`
+		Expect(err).To(BeNil())                         // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
+		ExpectWithOffset(1, err).To(BeNil())            // want `ginkgo-linter: wrong error assertion\nconsider using .ExpectWithOffset\(1, err\)\.ToNot\(HaveOccurred\(\)\). instead`
+		Expect(err).To(Not(BeNil()))                    // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(err\)\.To\(HaveOccurred\(\)\). instead`
+		Expect(err).ToNot(BeNil())                      // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(err\)\.To\(HaveOccurred\(\)\). instead`
 
-		Expect(tt.err).To(BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .Expect\(tt\.err\)\.ToNot\(HaveOccurred\(\)\). instead`
+		Expect(tt.err).To(BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(tt\.err\)\.ToNot\(HaveOccurred\(\)\). instead`
 
-		Expect(errFunc()).To(BeNil())      // want `ginkgo-linter: wrong error assertion; consider using .Expect\(errFunc\(\)\)\.To\(Succeed\(\)\). instead`
-		Expect(errFunc()).To(Not(BeNil())) // want `ginkgo-linter: wrong error assertion; consider using .Expect\(errFunc\(\)\)\.ToNot\(Succeed\(\)\). instead`
-		Expect(tupleFunc()).ToNot(BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .Expect\(tupleFunc\(\)\)\.ToNot\(Succeed\(\)\). instead`
+		Expect(errFunc()).To(BeNil())      // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(errFunc\(\)\)\.To\(Succeed\(\)\). instead`
+		Expect(errFunc()).To(Not(BeNil())) // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(errFunc\(\)\)\.ToNot\(Succeed\(\)\). instead`
+		Expect(tupleFunc()).ToNot(BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(tupleFunc\(\)\)\.ToNot\(Succeed\(\)\). instead`
 		Expect(noErrorFunc()).ToNot(Equal(1))
 
-		Expect(tt.typeErrorFunc()).ToNot(BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .Expect\(tt\.typeErrorFunc\(\)\)\.ToNot\(Succeed\(\)\). instead`
-		Expect(tt.typeTupleFunc()).ToNot(BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .Expect\(tt\.typeTupleFunc\(\)\)\.ToNot\(Succeed\(\)\). instead`
+		Expect(tt.typeErrorFunc()).ToNot(BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(tt\.typeErrorFunc\(\)\)\.ToNot\(Succeed\(\)\). instead`
+		Expect(tt.typeTupleFunc()).ToNot(BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(tt\.typeTupleFunc\(\)\)\.ToNot\(Succeed\(\)\). instead`
 		Expect(tt.typeNoErrorFunc()).ToNot(Equal(1))
 	})
 	It("check Expect(err).To(Equal(nil))", func() {
-		Expect(err).To(Equal(nil))      // want `ginkgo-linter: wrong error assertion; consider using .Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
-		Expect(err).To(Not(Equal(nil))) // want `ginkgo-linter: wrong error assertion; consider using .Expect\(err\)\.To\(HaveOccurred\(\)\). instead`
-		Expect(err).ToNot(Equal(nil))   // want `ginkgo-linter: wrong error assertion; consider using .Expect\(err\)\.To\(HaveOccurred\(\)\). instead`
-		Expect(tt.err).To(Equal(nil))   // want `ginkgo-linter: wrong error assertion; consider using .Expect\(tt\.err\)\.ToNot\(HaveOccurred\(\)\). instead`
+		Expect(err).To(Equal(nil))      // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
+		Expect(err).To(Not(Equal(nil))) // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(err\)\.To\(HaveOccurred\(\)\). instead`
+		Expect(err).ToNot(Equal(nil))   // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(err\)\.To\(HaveOccurred\(\)\). instead`
+		Expect(tt.err).To(Equal(nil))   // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(tt\.err\)\.ToNot\(HaveOccurred\(\)\). instead`
 
-		Expect(errFunc()).To(Equal(nil))      // want `ginkgo-linter: wrong error assertion; consider using .Expect\(errFunc\(\)\)\.To\(Succeed\(\)\). instead`
-		Expect(errFunc()).To(Not(Equal(nil))) // want `ginkgo-linter: wrong error assertion; consider using .Expect\(errFunc\(\)\)\.ToNot\(Succeed\(\)\). instead`
-		Expect(tupleFunc()).ToNot(Equal(nil)) // want `ginkgo-linter: wrong error assertion; consider using .Expect\(tupleFunc\(\)\)\.ToNot\(Succeed\(\)\). instead`
+		Expect(errFunc()).To(Equal(nil))      // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(errFunc\(\)\)\.To\(Succeed\(\)\). instead`
+		Expect(errFunc()).To(Not(Equal(nil))) // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(errFunc\(\)\)\.ToNot\(Succeed\(\)\). instead`
+		Expect(tupleFunc()).ToNot(Equal(nil)) // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(tupleFunc\(\)\)\.ToNot\(Succeed\(\)\). instead`
 		Expect(noErrorFunc()).ToNot(Equal(1))
 
-		Expect(tt.typeErrorFunc()).ToNot(Equal(nil)) // want `ginkgo-linter: wrong error assertion; consider using .Expect\(tt.typeErrorFunc\(\)\)\.ToNot\(Succeed\(\)\). instead`
-		Expect(tt.typeTupleFunc()).ToNot(Equal(nil)) // want `ginkgo-linter: wrong error assertion; consider using .Expect\(tt.typeTupleFunc\(\)\)\.ToNot\(Succeed\(\)\). instead`
+		Expect(tt.typeErrorFunc()).ToNot(Equal(nil)) // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(tt.typeErrorFunc\(\)\)\.ToNot\(Succeed\(\)\). instead`
+		Expect(tt.typeTupleFunc()).ToNot(Equal(nil)) // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(tt.typeTupleFunc\(\)\)\.ToNot\(Succeed\(\)\). instead`
 		Expect(tt.typeTupleFunc()).ToNot(HaveOccurred())
 		Expect(tt.typeTupleFunc()).To(Succeed())
 		Expect(tt.typeNoErrorFunc()).ToNot(Equal(1))
 	})
 
 	It("check err == nil", func() {
-		Expect(err == nil).To(Equal(true))       // want `ginkgo-linter: wrong error assertion; consider using .Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
-		Expect(err == nil).To(Equal(false))      // want `ginkgo-linter: wrong error assertion; consider using .Expect\(err\)\.To\(HaveOccurred\(\)\). instead`
-		Expect(err != nil).To(Equal(true))       // want `ginkgo-linter: wrong error assertion; consider using .Expect\(err\)\.To\(HaveOccurred\(\)\). instead`
-		Expect(err != nil).To(Equal(false))      // want `ginkgo-linter: wrong error assertion; consider using .Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
-		Expect(nil == err).To(Equal(true))       // want `ginkgo-linter: wrong error assertion; consider using .Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
-		Expect(nil == errFunc()).To(Equal(true)) // want `ginkgo-linter: wrong error assertion; consider using .Expect\(errFunc\(\)\)\.To\(Succeed\(\)\). instead`
-		Expect(errFunc() != nil).To(Equal(true)) // want `ginkgo-linter: wrong error assertion; consider using .Expect\(errFunc\(\)\)\.ToNot\(Succeed\(\)\). instead`
+		Expect(err == nil).To(Equal(true))       // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
+		Expect(err == nil).To(Equal(false))      // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(err\)\.To\(HaveOccurred\(\)\). instead`
+		Expect(err != nil).To(Equal(true))       // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(err\)\.To\(HaveOccurred\(\)\). instead`
+		Expect(err != nil).To(Equal(false))      // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
+		Expect(nil == err).To(Equal(true))       // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
+		Expect(nil == errFunc()).To(Equal(true)) // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(errFunc\(\)\)\.To\(Succeed\(\)\). instead`
+		Expect(errFunc() != nil).To(Equal(true)) // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(errFunc\(\)\)\.ToNot\(Succeed\(\)\). instead`
 
-		Expect(err == nil).To(BeTrue())        // want `ginkgo-linter: wrong error assertion; consider using .Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
-		Expect(err != nil).To(BeFalse())       // want `ginkgo-linter: wrong error assertion; consider using .Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
-		Expect(nil == err).To(BeTrue())        // want `ginkgo-linter: wrong error assertion; consider using .Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
-		Expect(nil == errFunc()).To(BeTrue())  // want `ginkgo-linter: wrong error assertion; consider using .Expect\(errFunc\(\)\)\.To\(Succeed\(\)\). instead`
-		Expect(errFunc() != nil).To(BeFalse()) // want `ginkgo-linter: wrong error assertion; consider using .Expect\(errFunc\(\)\)\.To\(Succeed\(\)\). instead`
+		Expect(err == nil).To(BeTrue())        // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
+		Expect(err != nil).To(BeFalse())       // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
+		Expect(nil == err).To(BeTrue())        // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
+		Expect(nil == errFunc()).To(BeTrue())  // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(errFunc\(\)\)\.To\(Succeed\(\)\). instead`
+		Expect(errFunc() != nil).To(BeFalse()) // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(errFunc\(\)\)\.To\(Succeed\(\)\). instead`
 	})
 })

--- a/testdata/src/a/errnil/b.go
+++ b/testdata/src/a/errnil/b.go
@@ -12,29 +12,29 @@ var _ = Describe("check Expect(err).To(BeNil())", func() {
 	tt := t{}
 
 	It("check Expect(err).To(BeNil())", func() {
-		gomega.Expect(errors.New("fake error")).To(gomega.Equal(nil)) // want `ginkgo-linter: wrong error assertion; consider using .gomega\.Expect\(errors\.New\("fake error"\)\)\.To\(gomega\.Succeed\(\)\). instead`
-		gomega.Expect(err).To(gomega.BeNil())                         // want `ginkgo-linter: wrong error assertion; consider using .gomega\.Expect\(err\)\.ToNot\(gomega\.HaveOccurred\(\)\). instead`
-		gomega.ExpectWithOffset(1, err).To(gomega.BeNil())            // want `ginkgo-linter: wrong error assertion; consider using .gomega\.ExpectWithOffset\(1, err\)\.ToNot\(gomega\.HaveOccurred\(\)\). instead`
-		gomega.Expect(err).To(gomega.Not(gomega.BeNil()))             // want `ginkgo-linter: wrong error assertion; consider using .gomega\.Expect\(err\)\.To\(gomega\.HaveOccurred\(\)\). instead`
-		gomega.Expect(err).ToNot(gomega.BeNil())                      // want `ginkgo-linter: wrong error assertion; consider using .gomega\.Expect\(err\)\.To\(gomega\.HaveOccurred\(\)\). instead`
+		gomega.Expect(errors.New("fake error")).To(gomega.Equal(nil)) // want `ginkgo-linter: wrong error assertion\nconsider using .gomega\.Expect\(errors\.New\("fake error"\)\)\.To\(gomega\.Succeed\(\)\). instead`
+		gomega.Expect(err).To(gomega.BeNil())                         // want `ginkgo-linter: wrong error assertion\nconsider using .gomega\.Expect\(err\)\.ToNot\(gomega\.HaveOccurred\(\)\). instead`
+		gomega.ExpectWithOffset(1, err).To(gomega.BeNil())            // want `ginkgo-linter: wrong error assertion\nconsider using .gomega\.ExpectWithOffset\(1, err\)\.ToNot\(gomega\.HaveOccurred\(\)\). instead`
+		gomega.Expect(err).To(gomega.Not(gomega.BeNil()))             // want `ginkgo-linter: wrong error assertion\nconsider using .gomega\.Expect\(err\)\.To\(gomega\.HaveOccurred\(\)\). instead`
+		gomega.Expect(err).ToNot(gomega.BeNil())                      // want `ginkgo-linter: wrong error assertion\nconsider using .gomega\.Expect\(err\)\.To\(gomega\.HaveOccurred\(\)\). instead`
 
-		gomega.Expect(tt.err).To(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .gomega\.Expect\(tt\.err\)\.ToNot\(gomega\.HaveOccurred\(\)\). instead`
+		gomega.Expect(tt.err).To(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .gomega\.Expect\(tt\.err\)\.ToNot\(gomega\.HaveOccurred\(\)\). instead`
 
-		gomega.Expect(errFunc()).To(gomega.BeNil())             // want `ginkgo-linter: wrong error assertion; consider using .gomega\.Expect\(errFunc\(\)\)\.To\(gomega\.Succeed\(\)\). instead`
-		gomega.Expect(errFunc()).To(gomega.Not(gomega.BeNil())) // want `ginkgo-linter: wrong error assertion; consider using .gomega\.Expect\(errFunc\(\)\)\.ToNot\(gomega\.Succeed\(\)\). instead`
-		gomega.Expect(tupleFunc()).ToNot(gomega.BeNil())        // want `ginkgo-linter: wrong error assertion; consider using .gomega\.Expect\(tupleFunc\(\)\)\.ToNot\(gomega\.Succeed\(\)\). instead`
+		gomega.Expect(errFunc()).To(gomega.BeNil())             // want `ginkgo-linter: wrong error assertion\nconsider using .gomega\.Expect\(errFunc\(\)\)\.To\(gomega\.Succeed\(\)\). instead`
+		gomega.Expect(errFunc()).To(gomega.Not(gomega.BeNil())) // want `ginkgo-linter: wrong error assertion\nconsider using .gomega\.Expect\(errFunc\(\)\)\.ToNot\(gomega\.Succeed\(\)\). instead`
+		gomega.Expect(tupleFunc()).ToNot(gomega.BeNil())        // want `ginkgo-linter: wrong error assertion\nconsider using .gomega\.Expect\(tupleFunc\(\)\)\.ToNot\(gomega\.Succeed\(\)\). instead`
 		gomega.Expect(noErrorFunc()).ToNot(gomega.Equal(1))
 
-		gomega.Expect(tt.typeErrorFunc()).ToNot(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .gomega\.Expect\(tt\.typeErrorFunc\(\)\)\.ToNot\(gomega\.Succeed\(\)\). instead`
-		gomega.Expect(tt.typeTupleFunc()).ToNot(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .gomega\.Expect\(tt\.typeTupleFunc\(\)\)\.ToNot\(gomega\.Succeed\(\)\). instead`
+		gomega.Expect(tt.typeErrorFunc()).ToNot(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .gomega\.Expect\(tt\.typeErrorFunc\(\)\)\.ToNot\(gomega\.Succeed\(\)\). instead`
+		gomega.Expect(tt.typeTupleFunc()).ToNot(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .gomega\.Expect\(tt\.typeTupleFunc\(\)\)\.ToNot\(gomega\.Succeed\(\)\). instead`
 		gomega.Expect(tt.typeNoErrorFunc()).ToNot(gomega.Equal(1))
 	})
 
 	It("check err == nil", func() {
-		gomega.Expect(err == nil).To(gomega.BeTrue())        // want `ginkgo-linter: wrong error assertion; consider using .gomega\.Expect\(err\)\.ToNot\(gomega\.HaveOccurred\(\)\). instead`
-		gomega.Expect(err != nil).To(gomega.BeFalse())       // want `ginkgo-linter: wrong error assertion; consider using .gomega\.Expect\(err\)\.ToNot\(gomega\.HaveOccurred\(\)\). instead`
-		gomega.Expect(nil == err).To(gomega.BeTrue())        // want `ginkgo-linter: wrong error assertion; consider using .gomega\.Expect\(err\)\.ToNot\(gomega\.HaveOccurred\(\)\). instead`
-		gomega.Expect(nil == errFunc()).To(gomega.BeTrue())  // want `ginkgo-linter: wrong error assertion; consider using .gomega\.Expect\(errFunc\(\)\)\.To\(gomega\.Succeed\(\)\). instead`
-		gomega.Expect(errFunc() != nil).To(gomega.BeFalse()) // want `ginkgo-linter: wrong error assertion; consider using .gomega\.Expect\(errFunc\(\)\)\.To\(gomega\.Succeed\(\)\). instead`
+		gomega.Expect(err == nil).To(gomega.BeTrue())        // want `ginkgo-linter: wrong error assertion\nconsider using .gomega\.Expect\(err\)\.ToNot\(gomega\.HaveOccurred\(\)\). instead`
+		gomega.Expect(err != nil).To(gomega.BeFalse())       // want `ginkgo-linter: wrong error assertion\nconsider using .gomega\.Expect\(err\)\.ToNot\(gomega\.HaveOccurred\(\)\). instead`
+		gomega.Expect(nil == err).To(gomega.BeTrue())        // want `ginkgo-linter: wrong error assertion\nconsider using .gomega\.Expect\(err\)\.ToNot\(gomega\.HaveOccurred\(\)\). instead`
+		gomega.Expect(nil == errFunc()).To(gomega.BeTrue())  // want `ginkgo-linter: wrong error assertion\nconsider using .gomega\.Expect\(errFunc\(\)\)\.To\(gomega\.Succeed\(\)\). instead`
+		gomega.Expect(errFunc() != nil).To(gomega.BeFalse()) // want `ginkgo-linter: wrong error assertion\nconsider using .gomega\.Expect\(errFunc\(\)\)\.To\(gomega\.Succeed\(\)\). instead`
 	})
 })

--- a/testdata/src/a/gomegaonly/gomegaonly_test.go
+++ b/testdata/src/a/gomegaonly/gomegaonly_test.go
@@ -11,29 +11,29 @@ func TestGomegaOnly_NewGomegaWithT(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	var err error
-	g.Expect(err).ToNot(BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.To\(HaveOccurred\(\)\). instead`
+	g.Expect(err).ToNot(BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .g\.Expect\(err\)\.To\(HaveOccurred\(\)\). instead`
 	assert(g, err)
 	assertWithT(g, err)
 	assertGomegaWithT(g, err)
 }
 
 func assert(g Gomega, err error) {
-	g.Expect(err).To(BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
+	g.Expect(err).To(BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .g\.Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
 }
 
 func assertWithT(g *WithT, err error) {
-	g.Expect(err).To(BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
+	g.Expect(err).To(BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .g\.Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
 }
 
 func assertGomegaWithT(g *GomegaWithT, err error) {
-	g.Expect(err).To(BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
+	g.Expect(err).To(BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .g\.Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
 }
 
 func TestGomegaOnly_NewWithT(t *testing.T) {
 	g := NewWithT(t)
 
 	var err error
-	g.Expect(err).ToNot(BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.To\(HaveOccurred\(\)\). instead`
+	g.Expect(err).ToNot(BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .g\.Expect\(err\)\.To\(HaveOccurred\(\)\). instead`
 	assert(g, err)
 }
 
@@ -41,14 +41,14 @@ func TestGomegaOnly_NewGomega(t *testing.T) {
 	g := NewGomega(Fail)
 
 	var err error
-	g.Expect(err).ToNot(BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.To\(HaveOccurred\(\)\). instead`
+	g.Expect(err).ToNot(BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .g\.Expect\(err\)\.To\(HaveOccurred\(\)\). instead`
 	assert(g, err)
 }
 
 var _ = Describe("check gomega parameter", func() {
 	Eventually(func(g Gomega) error {
 		arr := []int{1, 2, 3}
-		g.Expect(len(arr)).Should(Equal(3)) // want `ginkgo-linter: wrong length assertion; consider using .g\.Expect\(arr\)\.Should\(HaveLen\(3\)\). instead`
+		g.Expect(len(arr)).Should(Equal(3)) // want `ginkgo-linter: wrong length assertion\nconsider using .g\.Expect\(arr\)\.Should\(HaveLen\(3\)\). instead`
 		return nil
 	}).Should(Succeed())
 })

--- a/testdata/src/a/gomegaonly/gomegaonly_w_mod_name_test.go
+++ b/testdata/src/a/gomegaonly/gomegaonly_w_mod_name_test.go
@@ -11,7 +11,7 @@ func TestGomegaOnlyWithModName_NewGomegaWithT(t *testing.T) {
 	g := gom.NewGomegaWithT(t)
 
 	var err error
-	g.Expect(err).ToNot(gom.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.To\(gom.HaveOccurred\(\)\). instead`
+	g.Expect(err).ToNot(gom.BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .g\.Expect\(err\)\.To\(gom.HaveOccurred\(\)\). instead`
 
 	assertWithModName(g, err)
 	assertWithNameModWithT(g, err)
@@ -22,32 +22,32 @@ func TestGomegaOnlyWithModName_NewWithT(t *testing.T) {
 	g := gom.NewWithT(t)
 
 	var err error
-	g.Expect(err).ToNot(gom.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.To\(gom.HaveOccurred\(\)\). instead`
+	g.Expect(err).ToNot(gom.BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .g\.Expect\(err\)\.To\(gom.HaveOccurred\(\)\). instead`
 }
 
 func TestGomegaOnlyWithModName_NewGomega(t *testing.T) {
 	g := gom.NewGomega(Fail)
 
 	var err error
-	g.Expect(err).ToNot(gom.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.To\(gom.HaveOccurred\(\)\). instead`
+	g.Expect(err).ToNot(gom.BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .g\.Expect\(err\)\.To\(gom.HaveOccurred\(\)\). instead`
 }
 
 func assertWithModName(g gom.Gomega, err error) {
-	g.Expect(err).To(gom.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.ToNot\(gom\.HaveOccurred\(\)\). instead`
+	g.Expect(err).To(gom.BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .g\.Expect\(err\)\.ToNot\(gom\.HaveOccurred\(\)\). instead`
 }
 
 func assertWithNameModWithT(g *gom.WithT, err error) {
-	g.Expect(err).To(gom.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.ToNot\(gom\.HaveOccurred\(\)\). instead`
+	g.Expect(err).To(gom.BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .g\.Expect\(err\)\.ToNot\(gom\.HaveOccurred\(\)\). instead`
 }
 
 func assertWithModNameGomegaWithT(g *gom.WithT, err error) {
-	g.Expect(err).To(gom.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.ToNot\(gom\.HaveOccurred\(\)\). instead`
+	g.Expect(err).To(gom.BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .g\.Expect\(err\)\.ToNot\(gom\.HaveOccurred\(\)\). instead`
 }
 
 var _ = Describe("check gomega parameter", func() {
 	gom.Eventually(func(g gom.Gomega) error {
 		arr := []int{1, 2, 3}
-		g.Expect(len(arr)).Should(gom.Equal(3)) // want `ginkgo-linter: wrong length assertion; consider using .g\.Expect\(arr\)\.Should\(gom\.HaveLen\(3\)\). instead`
+		g.Expect(len(arr)).Should(gom.Equal(3)) // want `ginkgo-linter: wrong length assertion\nconsider using .g\.Expect\(arr\)\.Should\(gom\.HaveLen\(3\)\). instead`
 		return nil
 	}).Should(gom.Succeed())
 })

--- a/testdata/src/a/gomegaonly/gomegaonly_w_name_test.go
+++ b/testdata/src/a/gomegaonly/gomegaonly_w_name_test.go
@@ -11,7 +11,7 @@ func TestGomegaOnlyWithName_NewGomegaWithT(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	var err error
-	g.Expect(err).ToNot(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.To\(gomega.HaveOccurred\(\)\). instead`
+	g.Expect(err).ToNot(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .g\.Expect\(err\)\.To\(gomega.HaveOccurred\(\)\). instead`
 
 	assertWithName(g, err)
 	assertWithNameWithT(g, err)
@@ -22,32 +22,32 @@ func TestGomegaOnlyWithName_NewWithT(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	var err error
-	g.Expect(err).ToNot(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.To\(gomega.HaveOccurred\(\)\). instead`
+	g.Expect(err).ToNot(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .g\.Expect\(err\)\.To\(gomega.HaveOccurred\(\)\). instead`
 }
 
 func TestGomegaOnlyWithName_NewGomega(t *testing.T) {
 	g := gomega.NewGomega(Fail)
 
 	var err error
-	g.Expect(err).ToNot(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.To\(gomega.HaveOccurred\(\)\). instead`
+	g.Expect(err).ToNot(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .g\.Expect\(err\)\.To\(gomega.HaveOccurred\(\)\). instead`
 }
 
 func assertWithName(g gomega.Gomega, err error) {
-	g.Expect(err).To(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.ToNot\(gomega\.HaveOccurred\(\)\). instead`
+	g.Expect(err).To(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .g\.Expect\(err\)\.ToNot\(gomega\.HaveOccurred\(\)\). instead`
 }
 
 func assertWithNameWithT(g *gomega.WithT, err error) {
-	g.Expect(err).To(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.ToNot\(gomega\.HaveOccurred\(\)\). instead`
+	g.Expect(err).To(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .g\.Expect\(err\)\.ToNot\(gomega\.HaveOccurred\(\)\). instead`
 }
 
 func assertWithNameGomegaWithT(g *gomega.WithT, err error) {
-	g.Expect(err).To(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion; consider using .g\.Expect\(err\)\.ToNot\(gomega\.HaveOccurred\(\)\). instead`
+	g.Expect(err).To(gomega.BeNil()) // want `ginkgo-linter: wrong error assertion\nconsider using .g\.Expect\(err\)\.ToNot\(gomega\.HaveOccurred\(\)\). instead`
 }
 
 var _ = Describe("check gomega parameter", func() {
 	gomega.Eventually(func(g gomega.Gomega) error {
 		arr := []int{1, 2, 3}
-		g.Expect(len(arr)).Should(gomega.Equal(3)) // want `ginkgo-linter: wrong length assertion; consider using .g\.Expect\(arr\)\.Should\(gomega\.HaveLen\(3\)\). instead`
+		g.Expect(len(arr)).Should(gomega.Equal(3)) // want `ginkgo-linter: wrong length assertion\nconsider using .g\.Expect\(arr\)\.Should\(gomega\.HaveLen\(3\)\). instead`
 		return nil
 	}).Should(gomega.Succeed())
 })

--- a/testdata/src/a/havelen0/gomega.go
+++ b/testdata/src/a/havelen0/gomega.go
@@ -10,8 +10,8 @@ func TestHaveLen0(t *testing.T) {
 	g := NewWithT(t)
 
 	x := make([]int, 0)
-	g.Expect(x).Should(HaveLen(0)) // want `ginkgo-linter: wrong length assertion; consider using .g\.Expect\(x\)\.Should\(BeEmpty\(\)\). instead`
+	g.Expect(x).Should(HaveLen(0)) // want `ginkgo-linter: wrong length assertion\nconsider using .g\.Expect\(x\)\.Should\(BeEmpty\(\)\). instead`
 
 	x = append(x, 1)
-	g.Expect(x).Should(Not(HaveLen(0))) // want `ginkgo-linter: wrong length assertion; consider using .g\.Expect\(x\)\.ShouldNot\(BeEmpty\(\)\). instead`
+	g.Expect(x).Should(Not(HaveLen(0))) // want `ginkgo-linter: wrong length assertion\nconsider using .g\.Expect\(x\)\.ShouldNot\(BeEmpty\(\)\). instead`
 }

--- a/testdata/src/a/havelen0/havelen0.go
+++ b/testdata/src/a/havelen0/havelen0.go
@@ -10,9 +10,9 @@ const EMPTY = 0
 var _ = Describe("test HaveLen(0)", func() {
 	It("should replace HaveLen(0) with BeEmpty()", func() {
 		x := make([]int, 0)
-		Expect(x).To(HaveLen(0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(x\)\.To\(BeEmpty\(\)\). instead`
+		Expect(x).To(HaveLen(0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\(x\)\.To\(BeEmpty\(\)\). instead`
 
 		x = append(x, 1)
-		Expect(x).To(Not(HaveLen(0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(x\)\.ToNot\(BeEmpty\(\)\). instead`
+		Expect(x).To(Not(HaveLen(0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\(x\)\.ToNot\(BeEmpty\(\)\). instead`
 	})
 })

--- a/testdata/src/a/len/a.go
+++ b/testdata/src/a/len/a.go
@@ -9,23 +9,23 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 	Context("test Expect", func() {
 		Context("test Should", func() {
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).Should(Equal(4)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.Should\(HaveLen\(4\)\). instead`
+				Expect(len("abcd")).Should(Equal(4)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.Should\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("")).Should(Equal(0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(""\)\.Should\(BeEmpty\(\)\). instead`
+				Expect(len("")).Should(Equal(0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\(""\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("")).Should(BeZero()) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(""\)\.Should\(BeEmpty\(\)\). instead`
+				Expect(len("")).Should(BeZero()) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\(""\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ShouldNot BeEmpty", func() {
-				Expect(len("abcd")).Should(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).Should(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ShouldNot BeEmpty", func() {
-				Expect(len("abcd")).Should(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).Should(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -37,44 +37,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).Should(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.Should\(HaveLen\(11\)\). instead`
+				Expect(len("abcd")).Should(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.Should\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest ShouldNot HaveLen", func() {
-				Expect(len("abcd")).Should(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
+				Expect(len("abcd")).Should(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("abcd")).Should(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).Should(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ShouldNot BeEmpty", func() {
-				Expect(len("abcd")).Should(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).Should(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).Should(Equal(len("1234"))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.Should\(HaveLen\(len\("1234"\)\)\). instead`
+				Expect(len("abcd")).Should(Equal(len("1234"))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.Should\(HaveLen\(len\("1234"\)\)\). instead`
 			})
 		})
 		Context("test Should(Not", func() {
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).Should(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ShouldNot\(HaveLen\(4\)\). instead`
+				Expect(len("abcd")).Should(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ShouldNot\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("")).Should(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(""\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Expect(len("")).Should(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\(""\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("")).Should(Not(BeZero())) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(""\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Expect(len("")).Should(Not(BeZero())) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\(""\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Expect(len("abcd")).Should(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).Should(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Expect(len("abcd")).Should(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).Should(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -86,44 +86,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).Should(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
+				Expect(len("abcd")).Should(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest Should HaveLen", func() {
-				Expect(len("abcd")).Should(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.Should\(HaveLen\(11\)\). instead`
+				Expect(len("abcd")).Should(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.Should\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("abcd")).Should(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).Should(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Expect(len("abcd")).Should(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).Should(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).Should(Not(Equal(len("12345")))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ShouldNot\(HaveLen\(len\("12345"\)\)\). instead`
+				Expect(len("abcd")).Should(Not(Equal(len("12345")))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ShouldNot\(HaveLen\(len\("12345"\)\)\). instead`
 			})
 		})
 		Context("test ShouldNot", func() {
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).ShouldNot(Equal(4)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ShouldNot\(HaveLen\(4\)\). instead`
+				Expect(len("abcd")).ShouldNot(Equal(4)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ShouldNot\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("")).ShouldNot(Equal(0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(""\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Expect(len("")).ShouldNot(Equal(0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\(""\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("")).ShouldNot(BeZero()) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(""\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Expect(len("")).ShouldNot(BeZero()) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\(""\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Expect(len("abcd")).ShouldNot(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).ShouldNot(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Expect(len("abcd")).ShouldNot(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).ShouldNot(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -135,44 +135,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).ShouldNot(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
+				Expect(len("abcd")).ShouldNot(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest Should HaveLen", func() {
-				Expect(len("abcd")).ShouldNot(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.Should\(HaveLen\(11\)\). instead`
+				Expect(len("abcd")).ShouldNot(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.Should\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("abcd")).ShouldNot(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).ShouldNot(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Expect(len("abcd")).ShouldNot(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).ShouldNot(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).ShouldNot(Equal(len("12345"))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ShouldNot\(HaveLen\(len\("12345"\)\)\). instead`
+				Expect(len("abcd")).ShouldNot(Equal(len("12345"))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ShouldNot\(HaveLen\(len\("12345"\)\)\). instead`
 			})
 		})
 		Context("test ShouldNot(Not", func() {
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).ShouldNot(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.Should\(HaveLen\(4\)\). instead`
+				Expect(len("abcd")).ShouldNot(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.Should\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("")).ShouldNot(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(""\)\.Should\(BeEmpty\(\)\). instead`
+				Expect(len("")).ShouldNot(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\(""\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("")).ShouldNot(Not(BeZero())) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(""\)\.Should\(BeEmpty\(\)\). instead`
+				Expect(len("")).ShouldNot(Not(BeZero())) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\(""\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ShouldNot BeEmpty", func() {
-				Expect(len("abcd")).ShouldNot(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).ShouldNot(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ShouldNot BeEmpty", func() {
-				Expect(len("abcd")).ShouldNot(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).ShouldNot(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -184,44 +184,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).ShouldNot(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.Should\(HaveLen\(11\)\). instead`
+				Expect(len("abcd")).ShouldNot(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.Should\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest ShouldNot HaveLen", func() {
-				Expect(len("abcd")).ShouldNot(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
+				Expect(len("abcd")).ShouldNot(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("abcd")).ShouldNot(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).ShouldNot(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ShouldNot BeEmpty", func() {
-				Expect(len("abcd")).ShouldNot(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).ShouldNot(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).ShouldNot(Not(Equal(len("1234")))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.Should\(HaveLen\(len\("1234"\)\)\). instead`
+				Expect(len("abcd")).ShouldNot(Not(Equal(len("1234")))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.Should\(HaveLen\(len\("1234"\)\)\). instead`
 			})
 		})
 		Context("test To", func() {
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).To(Equal(4)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(HaveLen\(4\)\). instead`
+				Expect(len("abcd")).To(Equal(4)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("")).To(Equal(0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(""\)\.To\(BeEmpty\(\)\). instead`
+				Expect(len("")).To(Equal(0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\(""\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("")).To(BeZero()) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(""\)\.To\(BeEmpty\(\)\). instead`
+				Expect(len("")).To(BeZero()) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\(""\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ToNot BeEmpty", func() {
-				Expect(len("abcd")).To(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).To(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ToNot BeEmpty", func() {
-				Expect(len("abcd")).To(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).To(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -233,44 +233,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).To(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(HaveLen\(11\)\). instead`
+				Expect(len("abcd")).To(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest ToNot HaveLen", func() {
-				Expect(len("abcd")).To(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
+				Expect(len("abcd")).To(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("abcd")).To(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).To(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ToNot BeEmpty", func() {
-				Expect(len("abcd")).To(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).To(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).To(Equal(len("1234"))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(HaveLen\(len\("1234"\)\)\). instead`
+				Expect(len("abcd")).To(Equal(len("1234"))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(HaveLen\(len\("1234"\)\)\). instead`
 			})
 		})
 		Context("test To(Not", func() {
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).To(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ToNot\(HaveLen\(4\)\). instead`
+				Expect(len("abcd")).To(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ToNot\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("")).To(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(""\)\.ToNot\(BeEmpty\(\)\). instead`
+				Expect(len("")).To(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\(""\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("")).To(Not(BeZero())) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(""\)\.ToNot\(BeEmpty\(\)\). instead`
+				Expect(len("")).To(Not(BeZero())) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\(""\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest To BeEmpty", func() {
-				Expect(len("abcd")).To(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).To(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest To BeEmpty", func() {
-				Expect(len("abcd")).To(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).To(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -282,44 +282,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).To(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
+				Expect(len("abcd")).To(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest To HaveLen", func() {
-				Expect(len("abcd")).To(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(HaveLen\(11\)\). instead`
+				Expect(len("abcd")).To(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("abcd")).To(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).To(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest To BeEmpty", func() {
-				Expect(len("abcd")).To(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).To(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).To(Not(Equal(len("12345")))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ToNot\(HaveLen\(len\("12345"\)\)\). instead`
+				Expect(len("abcd")).To(Not(Equal(len("12345")))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ToNot\(HaveLen\(len\("12345"\)\)\). instead`
 			})
 		})
 		Context("test ToNot", func() {
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).ToNot(Equal(4)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ToNot\(HaveLen\(4\)\). instead`
+				Expect(len("abcd")).ToNot(Equal(4)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ToNot\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("")).ToNot(Equal(0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(""\)\.ToNot\(BeEmpty\(\)\). instead`
+				Expect(len("")).ToNot(Equal(0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\(""\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("")).ToNot(BeZero()) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(""\)\.ToNot\(BeEmpty\(\)\). instead`
+				Expect(len("")).ToNot(BeZero()) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\(""\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Expect(len("abcd")).ToNot(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).ToNot(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Expect(len("abcd")).ToNot(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).ToNot(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -331,44 +331,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).ToNot(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
+				Expect(len("abcd")).ToNot(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest Should HaveLen", func() {
-				Expect(len("abcd")).ToNot(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(HaveLen\(11\)\). instead`
+				Expect(len("abcd")).ToNot(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("abcd")).ToNot(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).ToNot(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Expect(len("abcd")).ToNot(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).ToNot(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).ToNot(Equal(len("12345"))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ToNot\(HaveLen\(len\("12345"\)\)\). instead`
+				Expect(len("abcd")).ToNot(Equal(len("12345"))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ToNot\(HaveLen\(len\("12345"\)\)\). instead`
 			})
 		})
 		Context("test ToNot(Not", func() {
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).ToNot(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(HaveLen\(4\)\). instead`
+				Expect(len("abcd")).ToNot(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("")).ToNot(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(""\)\.To\(BeEmpty\(\)\). instead`
+				Expect(len("")).ToNot(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\(""\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("")).ToNot(Not(BeZero())) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(""\)\.To\(BeEmpty\(\)\). instead`
+				Expect(len("")).ToNot(Not(BeZero())) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\(""\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ToNot BeEmpty", func() {
-				Expect(len("abcd")).ToNot(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).ToNot(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ToNot BeEmpty", func() {
-				Expect(len("abcd")).ToNot(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).ToNot(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -380,44 +380,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).ToNot(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(HaveLen\(11\)\). instead`
+				Expect(len("abcd")).ToNot(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest ToNot HaveLen", func() {
-				Expect(len("abcd")).ToNot(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
+				Expect(len("abcd")).ToNot(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("abcd")).ToNot(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).ToNot(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ToNot BeEmpty", func() {
-				Expect(len("abcd")).ToNot(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).ToNot(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).ToNot(Not(Equal(len("1234")))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\).To\(HaveLen\(len\("1234"\)\)\). instead`
+				Expect(len("abcd")).ToNot(Not(Equal(len("1234")))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\).To\(HaveLen\(len\("1234"\)\)\). instead`
 			})
 		})
 		Context("test NotTo", func() {
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).NotTo(Equal(4)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.NotTo\(HaveLen\(4\)\). instead`
+				Expect(len("abcd")).NotTo(Equal(4)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.NotTo\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("")).NotTo(Equal(0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(""\)\.NotTo\(BeEmpty\(\)\). instead`
+				Expect(len("")).NotTo(Equal(0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\(""\)\.NotTo\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("")).NotTo(BeZero()) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(""\)\.NotTo\(BeEmpty\(\)\). instead`
+				Expect(len("")).NotTo(BeZero()) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\(""\)\.NotTo\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Expect(len("abcd")).NotTo(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).NotTo(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Expect(len("abcd")).NotTo(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).NotTo(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -429,44 +429,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).NotTo(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.NotTo\(HaveLen\(11\)\). instead`
+				Expect(len("abcd")).NotTo(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.NotTo\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest Should HaveLen", func() {
-				Expect(len("abcd")).NotTo(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(HaveLen\(11\)\). instead`
+				Expect(len("abcd")).NotTo(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("abcd")).NotTo(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.NotTo\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).NotTo(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.NotTo\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Expect(len("abcd")).NotTo(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).NotTo(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).NotTo(Equal(len("12345"))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.NotTo\(HaveLen\(len\("12345"\)\)\). instead`
+				Expect(len("abcd")).NotTo(Equal(len("12345"))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.NotTo\(HaveLen\(len\("12345"\)\)\). instead`
 			})
 		})
 		Context("test NotTo(Not", func() {
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).NotTo(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(HaveLen\(4\)\). instead`
+				Expect(len("abcd")).NotTo(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("")).NotTo(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(""\)\.To\(BeEmpty\(\)\). instead`
+				Expect(len("")).NotTo(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\(""\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("")).NotTo(Not(BeZero())) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(""\)\.To\(BeEmpty\(\)\). instead`
+				Expect(len("")).NotTo(Not(BeZero())) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\(""\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest NotTo BeEmpty", func() {
-				Expect(len("abcd")).NotTo(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).NotTo(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest NotTo BeEmpty", func() {
-				Expect(len("abcd")).NotTo(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).NotTo(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -478,46 +478,46 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).NotTo(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(HaveLen\(11\)\). instead`
+				Expect(len("abcd")).NotTo(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest NotTo HaveLen", func() {
-				Expect(len("abcd")).NotTo(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
+				Expect(len("abcd")).NotTo(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Expect(len("abcd")).NotTo(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).NotTo(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest NotTo BeEmpty", func() {
-				Expect(len("abcd")).NotTo(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				Expect(len("abcd")).NotTo(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).NotTo(Not(Equal(len("1234")))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(HaveLen\(len\("1234"\)\)\). instead`
+				Expect(len("abcd")).NotTo(Not(Equal(len("1234")))) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abcd"\)\.To\(HaveLen\(len\("1234"\)\)\). instead`
 			})
 		})
 	})
 	Context("test ExpectWithOffset", func() {
 		Context("test Should", func() {
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).Should(Equal(4)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.Should\(HaveLen\(4\)\). instead`
+				ExpectWithOffset(12, len("abcd")).Should(Equal(4)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.Should\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("")).Should(Equal(0)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, ""\)\.Should\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("")).Should(Equal(0)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, ""\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("")).Should(BeZero()) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, ""\)\.Should\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("")).Should(BeZero()) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, ""\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ShouldNot BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).Should(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).Should(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ShouldNot BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).Should(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).Should(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -529,44 +529,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).Should(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.Should\(HaveLen\(11\)\). instead`
+				ExpectWithOffset(12, len("abcd")).Should(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.Should\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest ShouldNot HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).Should(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
+				ExpectWithOffset(12, len("abcd")).Should(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).Should(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).Should(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ShouldNot BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).Should(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).Should(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).Should(Equal(len("1234"))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.Should\(HaveLen\(len\("1234"\)\)\). instead`
+				ExpectWithOffset(12, len("abcd")).Should(Equal(len("1234"))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.Should\(HaveLen\(len\("1234"\)\)\). instead`
 			})
 		})
 		Context("test Should(Not", func() {
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).Should(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(HaveLen\(4\)\). instead`
+				ExpectWithOffset(12, len("abcd")).Should(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("")).Should(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, ""\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("")).Should(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, ""\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("")).Should(Not(BeZero())) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, ""\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("")).Should(Not(BeZero())) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, ""\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).Should(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).Should(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).Should(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).Should(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -578,44 +578,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).Should(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
+				ExpectWithOffset(12, len("abcd")).Should(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest Should HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).Should(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.Should\(HaveLen\(11\)\). instead`
+				ExpectWithOffset(12, len("abcd")).Should(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.Should\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).Should(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).Should(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).Should(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).Should(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).Should(Not(Equal(len("12345")))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(HaveLen\(len\("12345"\)\)\). instead`
+				ExpectWithOffset(12, len("abcd")).Should(Not(Equal(len("12345")))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(HaveLen\(len\("12345"\)\)\). instead`
 			})
 		})
 		Context("test ShouldNot", func() {
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).ShouldNot(Equal(4)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(HaveLen\(4\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ShouldNot(Equal(4)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("")).ShouldNot(Equal(0)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, ""\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("")).ShouldNot(Equal(0)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, ""\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("")).ShouldNot(BeZero()) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, ""\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("")).ShouldNot(BeZero()) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, ""\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).ShouldNot(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ShouldNot(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).ShouldNot(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ShouldNot(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -627,44 +627,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).ShouldNot(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ShouldNot(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest Should HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).ShouldNot(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.Should\(HaveLen\(11\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ShouldNot(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.Should\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).ShouldNot(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ShouldNot(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).ShouldNot(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ShouldNot(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).ShouldNot(Equal(len("12345"))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(HaveLen\(len\("12345"\)\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ShouldNot(Equal(len("12345"))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(HaveLen\(len\("12345"\)\)\). instead`
 			})
 		})
 		Context("test ShouldNot(Not", func() {
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.Should\(HaveLen\(4\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.Should\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("")).ShouldNot(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, ""\)\.Should\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("")).ShouldNot(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, ""\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("")).ShouldNot(Not(BeZero())) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, ""\)\.Should\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("")).ShouldNot(Not(BeZero())) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, ""\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ShouldNot BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ShouldNot BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -676,44 +676,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.Should\(HaveLen\(11\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.Should\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest ShouldNot HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ShouldNot BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(Equal(len("1234")))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.Should\(HaveLen\(len\("1234"\)\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ShouldNot(Not(Equal(len("1234")))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.Should\(HaveLen\(len\("1234"\)\)\). instead`
 			})
 		})
 		Context("test To", func() {
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).To(Equal(4)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(HaveLen\(4\)\). instead`
+				ExpectWithOffset(12, len("abcd")).To(Equal(4)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("")).To(Equal(0)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, ""\)\.To\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("")).To(Equal(0)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, ""\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("")).To(BeZero()) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, ""\)\.To\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("")).To(BeZero()) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, ""\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ToNot BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).To(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).To(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ToNot BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).To(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).To(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -725,44 +725,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).To(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(HaveLen\(11\)\). instead`
+				ExpectWithOffset(12, len("abcd")).To(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest ToNot HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).To(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
+				ExpectWithOffset(12, len("abcd")).To(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).To(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).To(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ToNot BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).To(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).To(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).To(Equal(len("1234"))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(HaveLen\(len\("1234"\)\)\). instead`
+				ExpectWithOffset(12, len("abcd")).To(Equal(len("1234"))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(HaveLen\(len\("1234"\)\)\). instead`
 			})
 		})
 		Context("test To(Not", func() {
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).To(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(HaveLen\(4\)\). instead`
+				ExpectWithOffset(12, len("abcd")).To(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("")).To(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, ""\)\.ToNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("")).To(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, ""\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("")).To(Not(BeZero())) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, ""\)\.ToNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("")).To(Not(BeZero())) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, ""\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest To BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).To(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).To(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest To BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).To(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).To(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -774,44 +774,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).To(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
+				ExpectWithOffset(12, len("abcd")).To(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest To HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).To(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(HaveLen\(11\)\). instead`
+				ExpectWithOffset(12, len("abcd")).To(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).To(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).To(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest To BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).To(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).To(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).To(Not(Equal(len("12345")))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(HaveLen\(len\("12345"\)\)\). instead`
+				ExpectWithOffset(12, len("abcd")).To(Not(Equal(len("12345")))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(HaveLen\(len\("12345"\)\)\). instead`
 			})
 		})
 		Context("test ToNot", func() {
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).ToNot(Equal(4)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(HaveLen\(4\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ToNot(Equal(4)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("")).ToNot(Equal(0)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, ""\)\.ToNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("")).ToNot(Equal(0)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, ""\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("")).ToNot(BeZero()) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, ""\)\.ToNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("")).ToNot(BeZero()) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, ""\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).ToNot(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ToNot(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).ToNot(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ToNot(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -823,44 +823,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).ToNot(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ToNot(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest Should HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).ToNot(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(HaveLen\(11\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ToNot(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).ToNot(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ToNot(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).ToNot(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ToNot(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).ToNot(Equal(len("12345"))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(HaveLen\(len\("12345"\)\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ToNot(Equal(len("12345"))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(HaveLen\(len\("12345"\)\)\). instead`
 			})
 		})
 		Context("test ToNot(Not", func() {
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).ToNot(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(HaveLen\(4\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ToNot(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("")).ToNot(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, ""\)\.To\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("")).ToNot(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, ""\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("")).ToNot(Not(BeZero())) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, ""\)\.To\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("")).ToNot(Not(BeZero())) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, ""\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ToNot BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).ToNot(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ToNot(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ToNot BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).ToNot(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ToNot(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -872,44 +872,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).ToNot(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(HaveLen\(11\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ToNot(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest ToNot HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).ToNot(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ToNot(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).ToNot(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ToNot(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ToNot BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).ToNot(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ToNot(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).ToNot(Not(Equal(len("1234")))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\).To\(HaveLen\(len\("1234"\)\)\). instead`
+				ExpectWithOffset(12, len("abcd")).ToNot(Not(Equal(len("1234")))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\).To\(HaveLen\(len\("1234"\)\)\). instead`
 			})
 		})
 		Context("test NotTo", func() {
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).NotTo(Equal(4)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.NotTo\(HaveLen\(4\)\). instead`
+				ExpectWithOffset(12, len("abcd")).NotTo(Equal(4)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.NotTo\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("")).NotTo(Equal(0)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, ""\)\.NotTo\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("")).NotTo(Equal(0)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, ""\)\.NotTo\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("")).NotTo(BeZero()) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, ""\)\.NotTo\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("")).NotTo(BeZero()) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, ""\)\.NotTo\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).NotTo(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).NotTo(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).NotTo(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).NotTo(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -921,44 +921,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).NotTo(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.NotTo\(HaveLen\(11\)\). instead`
+				ExpectWithOffset(12, len("abcd")).NotTo(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.NotTo\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest Should HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).NotTo(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(HaveLen\(11\)\). instead`
+				ExpectWithOffset(12, len("abcd")).NotTo(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).NotTo(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.NotTo\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).NotTo(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.NotTo\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).NotTo(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).NotTo(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).NotTo(Equal(len("12345"))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.NotTo\(HaveLen\(len\("12345"\)\)\). instead`
+				ExpectWithOffset(12, len("abcd")).NotTo(Equal(len("12345"))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.NotTo\(HaveLen\(len\("12345"\)\)\). instead`
 			})
 		})
 		Context("test NotTo(Not", func() {
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).NotTo(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(HaveLen\(4\)\). instead`
+				ExpectWithOffset(12, len("abcd")).NotTo(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("")).NotTo(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, ""\)\.To\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("")).NotTo(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, ""\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("")).NotTo(Not(BeZero())) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, ""\)\.To\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("")).NotTo(Not(BeZero())) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, ""\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest NotTo BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).NotTo(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).NotTo(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest NotTo BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).NotTo(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).NotTo(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -970,46 +970,46 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).NotTo(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(HaveLen\(11\)\). instead`
+				ExpectWithOffset(12, len("abcd")).NotTo(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest NotTo HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).NotTo(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
+				ExpectWithOffset(12, len("abcd")).NotTo(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).NotTo(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).NotTo(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest NotTo BeEmpty", func() {
-				ExpectWithOffset(12, len("abcd")).NotTo(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				ExpectWithOffset(12, len("abcd")).NotTo(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				ExpectWithOffset(12, len("abcd")).NotTo(Not(Equal(len("1234")))) // want `ginkgo-linter: wrong length assertion; consider using .ExpectWithOffset\(12, "abcd"\)\.To\(HaveLen\(len\("1234"\)\)\). instead`
+				ExpectWithOffset(12, len("abcd")).NotTo(Not(Equal(len("1234")))) // want `ginkgo-linter: wrong length assertion\nconsider using .ExpectWithOffset\(12, "abcd"\)\.To\(HaveLen\(len\("1234"\)\)\). instead`
 			})
 		})
 	})
 	Context("test Ω", func() {
 		Context("test Should", func() {
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).Should(Equal(4)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.Should\(HaveLen\(4\)\). instead`
+				Ω(len("abcd")).Should(Equal(4)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.Should\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("")).Should(Equal(0)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\(""\)\.Should\(BeEmpty\(\)\). instead`
+				Ω(len("")).Should(Equal(0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\(""\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("")).Should(BeZero()) // want `ginkgo-linter: wrong length assertion; consider using .Ω\(""\)\.Should\(BeEmpty\(\)\). instead`
+				Ω(len("")).Should(BeZero()) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\(""\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ShouldNot BeEmpty", func() {
-				Ω(len("abcd")).Should(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).Should(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ShouldNot BeEmpty", func() {
-				Ω(len("abcd")).Should(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).Should(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -1021,44 +1021,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).Should(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.Should\(HaveLen\(11\)\). instead`
+				Ω(len("abcd")).Should(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.Should\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest ShouldNot HaveLen", func() {
-				Ω(len("abcd")).Should(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
+				Ω(len("abcd")).Should(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("abcd")).Should(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).Should(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ShouldNot BeEmpty", func() {
-				Ω(len("abcd")).Should(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).Should(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).Should(Equal(len("1234"))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.Should\(HaveLen\(len\("1234"\)\)\). instead`
+				Ω(len("abcd")).Should(Equal(len("1234"))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.Should\(HaveLen\(len\("1234"\)\)\). instead`
 			})
 		})
 		Context("test Should(Not", func() {
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).Should(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ShouldNot\(HaveLen\(4\)\). instead`
+				Ω(len("abcd")).Should(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ShouldNot\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("")).Should(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\(""\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Ω(len("")).Should(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\(""\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("")).Should(Not(BeZero())) // want `ginkgo-linter: wrong length assertion; consider using .Ω\(""\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Ω(len("")).Should(Not(BeZero())) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\(""\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Ω(len("abcd")).Should(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).Should(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Ω(len("abcd")).Should(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).Should(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -1070,44 +1070,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).Should(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
+				Ω(len("abcd")).Should(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest Should HaveLen", func() {
-				Ω(len("abcd")).Should(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.Should\(HaveLen\(11\)\). instead`
+				Ω(len("abcd")).Should(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.Should\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("abcd")).Should(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).Should(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Ω(len("abcd")).Should(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).Should(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).Should(Not(Equal(len("12345")))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ShouldNot\(HaveLen\(len\("12345"\)\)\). instead`
+				Ω(len("abcd")).Should(Not(Equal(len("12345")))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ShouldNot\(HaveLen\(len\("12345"\)\)\). instead`
 			})
 		})
 		Context("test ShouldNot", func() {
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).ShouldNot(Equal(4)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ShouldNot\(HaveLen\(4\)\). instead`
+				Ω(len("abcd")).ShouldNot(Equal(4)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ShouldNot\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("")).ShouldNot(Equal(0)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\(""\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Ω(len("")).ShouldNot(Equal(0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\(""\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("")).ShouldNot(BeZero()) // want `ginkgo-linter: wrong length assertion; consider using .Ω\(""\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Ω(len("")).ShouldNot(BeZero()) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\(""\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Ω(len("abcd")).ShouldNot(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).ShouldNot(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Ω(len("abcd")).ShouldNot(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).ShouldNot(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -1119,44 +1119,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).ShouldNot(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
+				Ω(len("abcd")).ShouldNot(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest Should HaveLen", func() {
-				Ω(len("abcd")).ShouldNot(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.Should\(HaveLen\(11\)\). instead`
+				Ω(len("abcd")).ShouldNot(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.Should\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("abcd")).ShouldNot(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).ShouldNot(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Ω(len("abcd")).ShouldNot(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).ShouldNot(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).ShouldNot(Equal(len("12345"))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ShouldNot\(HaveLen\(len\("12345"\)\)\). instead`
+				Ω(len("abcd")).ShouldNot(Equal(len("12345"))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ShouldNot\(HaveLen\(len\("12345"\)\)\). instead`
 			})
 		})
 		Context("test ShouldNot(Not", func() {
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).ShouldNot(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.Should\(HaveLen\(4\)\). instead`
+				Ω(len("abcd")).ShouldNot(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.Should\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("")).ShouldNot(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\(""\)\.Should\(BeEmpty\(\)\). instead`
+				Ω(len("")).ShouldNot(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\(""\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("")).ShouldNot(Not(BeZero())) // want `ginkgo-linter: wrong length assertion; consider using .Ω\(""\)\.Should\(BeEmpty\(\)\). instead`
+				Ω(len("")).ShouldNot(Not(BeZero())) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\(""\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ShouldNot BeEmpty", func() {
-				Ω(len("abcd")).ShouldNot(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).ShouldNot(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ShouldNot BeEmpty", func() {
-				Ω(len("abcd")).ShouldNot(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).ShouldNot(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -1168,44 +1168,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).ShouldNot(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.Should\(HaveLen\(11\)\). instead`
+				Ω(len("abcd")).ShouldNot(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.Should\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest ShouldNot HaveLen", func() {
-				Ω(len("abcd")).ShouldNot(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
+				Ω(len("abcd")).ShouldNot(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ShouldNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("abcd")).ShouldNot(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).ShouldNot(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.Should\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ShouldNot BeEmpty", func() {
-				Ω(len("abcd")).ShouldNot(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).ShouldNot(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ShouldNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).ShouldNot(Not(Equal(len("1234")))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.Should\(HaveLen\(len\("1234"\)\)\). instead`
+				Ω(len("abcd")).ShouldNot(Not(Equal(len("1234")))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.Should\(HaveLen\(len\("1234"\)\)\). instead`
 			})
 		})
 		Context("test To", func() {
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).To(Equal(4)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(HaveLen\(4\)\). instead`
+				Ω(len("abcd")).To(Equal(4)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("")).To(Equal(0)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\(""\)\.To\(BeEmpty\(\)\). instead`
+				Ω(len("")).To(Equal(0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\(""\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("")).To(BeZero()) // want `ginkgo-linter: wrong length assertion; consider using .Ω\(""\)\.To\(BeEmpty\(\)\). instead`
+				Ω(len("")).To(BeZero()) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\(""\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ToNot BeEmpty", func() {
-				Ω(len("abcd")).To(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).To(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ToNot BeEmpty", func() {
-				Ω(len("abcd")).To(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).To(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -1217,44 +1217,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).To(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(HaveLen\(11\)\). instead`
+				Ω(len("abcd")).To(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest ToNot HaveLen", func() {
-				Ω(len("abcd")).To(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
+				Ω(len("abcd")).To(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("abcd")).To(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).To(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ToNot BeEmpty", func() {
-				Ω(len("abcd")).To(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).To(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).To(Equal(len("1234"))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(HaveLen\(len\("1234"\)\)\). instead`
+				Ω(len("abcd")).To(Equal(len("1234"))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(HaveLen\(len\("1234"\)\)\). instead`
 			})
 		})
 		Context("test To(Not", func() {
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).To(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ToNot\(HaveLen\(4\)\). instead`
+				Ω(len("abcd")).To(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ToNot\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("")).To(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\(""\)\.ToNot\(BeEmpty\(\)\). instead`
+				Ω(len("")).To(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\(""\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("")).To(Not(BeZero())) // want `ginkgo-linter: wrong length assertion; consider using .Ω\(""\)\.ToNot\(BeEmpty\(\)\). instead`
+				Ω(len("")).To(Not(BeZero())) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\(""\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest To BeEmpty", func() {
-				Ω(len("abcd")).To(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).To(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest To BeEmpty", func() {
-				Ω(len("abcd")).To(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).To(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -1266,44 +1266,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).To(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
+				Ω(len("abcd")).To(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest To HaveLen", func() {
-				Ω(len("abcd")).To(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(HaveLen\(11\)\). instead`
+				Ω(len("abcd")).To(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("abcd")).To(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).To(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest To BeEmpty", func() {
-				Ω(len("abcd")).To(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).To(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).To(Not(Equal(len("12345")))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ToNot\(HaveLen\(len\("12345"\)\)\). instead`
+				Ω(len("abcd")).To(Not(Equal(len("12345")))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ToNot\(HaveLen\(len\("12345"\)\)\). instead`
 			})
 		})
 		Context("test ToNot", func() {
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).ToNot(Equal(4)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ToNot\(HaveLen\(4\)\). instead`
+				Ω(len("abcd")).ToNot(Equal(4)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ToNot\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("")).ToNot(Equal(0)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\(""\)\.ToNot\(BeEmpty\(\)\). instead`
+				Ω(len("")).ToNot(Equal(0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\(""\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("")).ToNot(BeZero()) // want `ginkgo-linter: wrong length assertion; consider using .Ω\(""\)\.ToNot\(BeEmpty\(\)\). instead`
+				Ω(len("")).ToNot(BeZero()) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\(""\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Ω(len("abcd")).ToNot(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).ToNot(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Ω(len("abcd")).ToNot(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).ToNot(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -1315,44 +1315,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).ToNot(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
+				Ω(len("abcd")).ToNot(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest Should HaveLen", func() {
-				Ω(len("abcd")).ToNot(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(HaveLen\(11\)\). instead`
+				Ω(len("abcd")).ToNot(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("abcd")).ToNot(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).ToNot(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Ω(len("abcd")).ToNot(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).ToNot(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).ToNot(Equal(len("12345"))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ToNot\(HaveLen\(len\("12345"\)\)\). instead`
+				Ω(len("abcd")).ToNot(Equal(len("12345"))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ToNot\(HaveLen\(len\("12345"\)\)\). instead`
 			})
 		})
 		Context("test ToNot(Not", func() {
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).ToNot(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(HaveLen\(4\)\). instead`
+				Ω(len("abcd")).ToNot(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("")).ToNot(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\(""\)\.To\(BeEmpty\(\)\). instead`
+				Ω(len("")).ToNot(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\(""\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("")).ToNot(Not(BeZero())) // want `ginkgo-linter: wrong length assertion; consider using .Ω\(""\)\.To\(BeEmpty\(\)\). instead`
+				Ω(len("")).ToNot(Not(BeZero())) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\(""\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ToNot BeEmpty", func() {
-				Ω(len("abcd")).ToNot(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).ToNot(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ToNot BeEmpty", func() {
-				Ω(len("abcd")).ToNot(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).ToNot(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -1364,44 +1364,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).ToNot(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(HaveLen\(11\)\). instead`
+				Ω(len("abcd")).ToNot(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest ToNot HaveLen", func() {
-				Ω(len("abcd")).ToNot(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
+				Ω(len("abcd")).ToNot(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("abcd")).ToNot(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).ToNot(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest ToNot BeEmpty", func() {
-				Ω(len("abcd")).ToNot(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).ToNot(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).ToNot(Not(Equal(len("1234")))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\).To\(HaveLen\(len\("1234"\)\)\). instead`
+				Ω(len("abcd")).ToNot(Not(Equal(len("1234")))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\).To\(HaveLen\(len\("1234"\)\)\). instead`
 			})
 		})
 		Context("test NotTo", func() {
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).NotTo(Equal(4)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.NotTo\(HaveLen\(4\)\). instead`
+				Ω(len("abcd")).NotTo(Equal(4)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.NotTo\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("")).NotTo(Equal(0)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\(""\)\.NotTo\(BeEmpty\(\)\). instead`
+				Ω(len("")).NotTo(Equal(0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\(""\)\.NotTo\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("")).NotTo(BeZero()) // want `ginkgo-linter: wrong length assertion; consider using .Ω\(""\)\.NotTo\(BeEmpty\(\)\). instead`
+				Ω(len("")).NotTo(BeZero()) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\(""\)\.NotTo\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Ω(len("abcd")).NotTo(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).NotTo(BeNumerically(">", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Ω(len("abcd")).NotTo(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).NotTo(BeNumerically(">=", 1)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -1413,44 +1413,44 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).NotTo(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.NotTo\(HaveLen\(11\)\). instead`
+				Ω(len("abcd")).NotTo(BeNumerically("==", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.NotTo\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest Should HaveLen", func() {
-				Ω(len("abcd")).NotTo(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(HaveLen\(11\)\). instead`
+				Ω(len("abcd")).NotTo(BeNumerically("!=", 11)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("abcd")).NotTo(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.NotTo\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).NotTo(BeNumerically("==", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.NotTo\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest Should BeEmpty", func() {
-				Ω(len("abcd")).NotTo(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).NotTo(BeNumerically("!=", 0)) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).NotTo(Equal(len("12345"))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.NotTo\(HaveLen\(len\("12345"\)\)\). instead`
+				Ω(len("abcd")).NotTo(Equal(len("12345"))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.NotTo\(HaveLen\(len\("12345"\)\)\). instead`
 			})
 		})
 		Context("test NotTo(Not", func() {
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).NotTo(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(HaveLen\(4\)\). instead`
+				Ω(len("abcd")).NotTo(Not(Equal(4))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("")).NotTo(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\(""\)\.To\(BeEmpty\(\)\). instead`
+				Ω(len("")).NotTo(Not(Equal(0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\(""\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("")).NotTo(Not(BeZero())) // want `ginkgo-linter: wrong length assertion; consider using .Ω\(""\)\.To\(BeEmpty\(\)\). instead`
+				Ω(len("")).NotTo(Not(BeZero())) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\(""\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest NotTo BeEmpty", func() {
-				Ω(len("abcd")).NotTo(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).NotTo(Not(BeNumerically(">", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest NotTo BeEmpty", func() {
-				Ω(len("abcd")).NotTo(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).NotTo(Not(BeNumerically(">=", 1))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should ignore other lengths", func() {
@@ -1462,23 +1462,23 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).NotTo(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(HaveLen\(11\)\). instead`
+				Ω(len("abcd")).NotTo(Not(BeNumerically("==", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest NotTo HaveLen", func() {
-				Ω(len("abcd")).NotTo(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
+				Ω(len("abcd")).NotTo(Not(BeNumerically("!=", 11))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ToNot\(HaveLen\(11\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {
-				Ω(len("abcd")).NotTo(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).NotTo(Not(BeNumerically("==", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest NotTo BeEmpty", func() {
-				Ω(len("abcd")).NotTo(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
+				Ω(len("abcd")).NotTo(Not(BeNumerically("!=", 0))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.ToNot\(BeEmpty\(\)\). instead`
 			})
 
 			It("should suggest HaveLen", func() {
-				Ω(len("abcd")).NotTo(Not(Equal(len("1234")))) // want `ginkgo-linter: wrong length assertion; consider using .Ω\("abcd"\)\.To\(HaveLen\(len\("1234"\)\)\). instead`
+				Ω(len("abcd")).NotTo(Not(Equal(len("1234")))) // want `ginkgo-linter: wrong length assertion\nconsider using .Ω\("abcd"\)\.To\(HaveLen\(len\("1234"\)\)\). instead`
 			})
 		})
 	})

--- a/testdata/src/a/nil/a.go
+++ b/testdata/src/a/nil/a.go
@@ -24,148 +24,148 @@ var _ = Describe("", func() {
 		Context("test Should", func() {
 			Context("test BeTrue", func() {
 				It("test nil value", func() {
-					Expect(x == nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil == x).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(x == nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil == x).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y != nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil != y).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(y != nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil != y).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() == nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil == fNil()).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(fNil() == nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil == fNil()).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() != nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil != fNotNil()).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() != nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil != fNotNil()).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test BeFalse", func() {
 				It("test nil value", func() {
-					Expect(x != nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil != x).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(x != nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil != x).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y == nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil == y).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(y == nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil == y).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() != nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil != fNil()).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(fNil() != nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil != fNil()).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() == nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil == fNotNil()).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() == nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil == fNotNil()).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(true)", func() {
 				It("test nil value", func() {
-					Expect(x == nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil == x).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(x == nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil == x).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y != nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil != y).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(y != nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil != y).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() == nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil == fNil()).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(fNil() == nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil == fNil()).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() != nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil != fNotNil()).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() != nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil != fNotNil()).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(false)", func() {
 				It("test nil value", func() {
-					Expect(x != nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil != x).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(x != nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil != x).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y == nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil == y).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(y == nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil == y).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() != nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil != fNil()).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(fNil() != nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil != fNil()).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() == nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil == fNotNil()).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() == nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil == fNotNil()).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 		})
 		Context("test Should(Not())", func() {
 			Context("test BeTrue", func() {
 				It("test nil value", func() {
-					Expect(x == nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil == x).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(x == nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil == x).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y != nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil != y).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(y != nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil != y).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() == nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil == fNil()).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(fNil() == nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil == fNil()).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() != nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil != fNotNil()).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() != nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil != fNotNil()).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test BeFalse", func() {
 				It("test nil value", func() {
-					Expect(x != nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil != x).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(x != nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil != x).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y == nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil == y).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(y == nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil == y).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() != nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil != fNil()).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(fNil() != nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil != fNil()).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() == nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil == fNotNil()).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() == nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil == fNotNil()).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(false)", func() {
 				It("test nil value", func() {
-					Expect(x == nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil == x).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(x == nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil == x).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y != nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil != y).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(y != nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil != y).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() == nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil == fNil()).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(fNil() == nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil == fNil()).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() != nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil != fNotNil()).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() != nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil != fNotNil()).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(true)", func() {
 				It("test nil value", func() {
-					Expect(x != nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil != x).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(x != nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil != x).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y == nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil == y).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(y == nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil == y).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() != nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil != fNil()).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(fNil() != nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil != fNil()).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() == nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil == fNotNil()).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() == nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil == fNotNil()).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 		})
@@ -173,148 +173,148 @@ var _ = Describe("", func() {
 		Context("test To", func() {
 			Context("test BeTrue", func() {
 				It("test nil value", func() {
-					Expect(x == nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
-					Expect(nil == x).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(x == nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(nil == x).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y != nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil != y).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(y != nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil != y).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() == nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Expect(nil == fNil()).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(fNil() == nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(nil == fNil()).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() != nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil != fNotNil()).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() != nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil != fNotNil()).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test BeFalse", func() {
 				It("test nil value", func() {
-					Expect(x != nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
-					Expect(nil != x).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(x != nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(nil != x).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y == nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil == y).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(y == nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil == y).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() != nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Expect(nil != fNil()).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(fNil() != nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(nil != fNil()).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() == nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil == fNotNil()).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() == nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil == fNotNil()).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(true)", func() {
 				It("test nil value", func() {
-					Expect(x == nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
-					Expect(nil == x).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(x == nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(nil == x).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y != nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil != y).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(y != nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil != y).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() == nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Expect(nil == fNil()).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(fNil() == nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(nil == fNil()).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() != nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil != fNotNil()).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() != nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil != fNotNil()).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(false)", func() {
 				It("test nil value", func() {
-					Expect(x != nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
-					Expect(nil != x).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(x != nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(nil != x).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y == nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil == y).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(y == nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil == y).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() != nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Expect(nil != fNil()).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(fNil() != nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(nil != fNil()).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() == nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil == fNotNil()).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() == nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil == fNotNil()).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 		})
 		Context("test To(Not())", func() {
 			Context("test BeTrue", func() {
 				It("test nil value", func() {
-					Expect(x == nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
-					Expect(nil == x).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(x == nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(nil == x).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y != nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil != y).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(y != nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil != y).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() == nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Expect(nil == fNil()).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(fNil() == nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(nil == fNil()).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() != nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil != fNotNil()).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() != nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil != fNotNil()).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test BeFalse", func() {
 				It("test nil value", func() {
-					Expect(x != nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
-					Expect(nil != x).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(x != nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(nil != x).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y == nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil == y).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(y == nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil == y).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() != nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Expect(nil != fNil()).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(fNil() != nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(nil != fNil()).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() == nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil == fNotNil()).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() == nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil == fNotNil()).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(false)", func() {
 				It("test nil value", func() {
-					Expect(x == nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
-					Expect(nil == x).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(x == nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(nil == x).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y != nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil != y).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(y != nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil != y).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() == nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Expect(nil == fNil()).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(fNil() == nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(nil == fNil()).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() != nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil != fNotNil()).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() != nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil != fNotNil()).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(true)", func() {
 				It("test nil value", func() {
-					Expect(x != nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
-					Expect(nil != x).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(x != nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(nil != x).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y == nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil == y).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(y == nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil == y).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() != nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Expect(nil != fNil()).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(fNil() != nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(nil != fNil()).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() == nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil == fNotNil()).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() == nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil == fNotNil()).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 		})
@@ -322,74 +322,74 @@ var _ = Describe("", func() {
 		Context("test ShouldNot", func() {
 			Context("test BeFalse", func() {
 				It("test nil value", func() {
-					Expect(x == nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil == x).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(x == nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil == x).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y != nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil != y).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(y != nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil != y).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() == nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil == fNil()).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(fNil() == nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil == fNil()).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() != nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil != fNotNil()).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() != nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil != fNotNil()).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test BeTrue", func() {
 				It("test nil value", func() {
-					Expect(x != nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil != x).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(x != nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil != x).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y == nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil == y).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(y == nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil == y).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() != nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil != fNil()).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(fNil() != nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil != fNil()).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() == nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil == fNotNil()).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() == nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil == fNotNil()).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(true)", func() {
 				It("test nil value", func() {
-					Expect(x != nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil != x).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(x != nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil != x).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y == nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil == y).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(y == nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil == y).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() != nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil != fNil()).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(fNil() != nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil != fNil()).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() == nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil == fNotNil()).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() == nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil == fNotNil()).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(false)", func() {
 				It("test nil value", func() {
-					Expect(x == nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil == x).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(x == nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil == x).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y != nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil != y).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(y != nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil != y).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() == nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil == fNil()).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(fNil() == nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil == fNil()).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() != nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Expect(nil != fNotNil()).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() != nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Expect(nil != fNotNil()).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 		})
@@ -397,148 +397,148 @@ var _ = Describe("", func() {
 		Context("test NotTo", func() {
 			Context("test BeFalse", func() {
 				It("test nil value", func() {
-					Expect(x == nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
-					Expect(nil == x).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(x == nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(nil == x).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y != nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil != y).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(y != nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil != y).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() == nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Expect(nil == fNil()).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(fNil() == nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(nil == fNil()).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() != nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil != fNotNil()).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() != nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil != fNotNil()).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test BeTrue", func() {
 				It("test nil value", func() {
-					Expect(x != nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
-					Expect(nil != x).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(x != nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(nil != x).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y == nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.NotTo\(BeNil\(\)\). instead`
-					Expect(nil == y).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.NotTo\(BeNil\(\)\). instead`
+					Expect(y == nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.NotTo\(BeNil\(\)\). instead`
+					Expect(nil == y).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.NotTo\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() != nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Expect(nil != fNil()).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(fNil() != nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(nil != fNil()).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() == nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
-					Expect(nil == fNotNil()).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
+					Expect(fNotNil() == nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
+					Expect(nil == fNotNil()).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(true)", func() {
 				It("test nil value", func() {
-					Expect(x != nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
-					Expect(nil != x).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(x != nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(nil != x).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y == nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.NotTo\(BeNil\(\)\). instead`
-					Expect(nil == y).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.NotTo\(BeNil\(\)\). instead`
+					Expect(y == nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.NotTo\(BeNil\(\)\). instead`
+					Expect(nil == y).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.NotTo\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() != nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Expect(nil != fNil()).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(fNil() != nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(nil != fNil()).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() == nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
-					Expect(nil == fNotNil()).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
+					Expect(fNotNil() == nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
+					Expect(nil == fNotNil()).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(false)", func() {
 				It("test nil value", func() {
-					Expect(x == nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
-					Expect(nil == x).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(x == nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(nil == x).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y != nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil != y).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(y != nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil != y).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() == nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Expect(nil == fNil()).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(fNil() == nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(nil == fNil()).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() != nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil != fNotNil()).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() != nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil != fNotNil()).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 		})
 		Context("test ToNot", func() {
 			Context("test BeFalse", func() {
 				It("test nil value", func() {
-					Expect(x == nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
-					Expect(nil == x).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(x == nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(nil == x).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y != nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil != y).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(y != nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil != y).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() == nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Expect(nil == fNil()).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(fNil() == nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(nil == fNil()).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() != nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil != fNotNil()).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() != nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil != fNotNil()).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test BeTrue", func() {
 				It("test nil value", func() {
-					Expect(x != nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
-					Expect(nil != x).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(x != nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(nil != x).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y == nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil == y).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(y == nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil == y).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() != nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Expect(nil != fNil()).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(fNil() != nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(nil != fNil()).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() == nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil == fNotNil()).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() == nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil == fNotNil()).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(true)", func() {
 				It("test nil value", func() {
-					Expect(x != nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
-					Expect(nil != x).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(x != nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(nil != x).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y == nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil == y).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(y == nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil == y).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() != nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Expect(nil != fNil()).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(fNil() != nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(nil != fNil()).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() == nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil == fNotNil()).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() == nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil == fNotNil()).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(false)", func() {
 				It("test nil value", func() {
-					Expect(x == nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
-					Expect(nil == x).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(x == nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
+					Expect(nil == x).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Expect(y != nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil != y).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(y != nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil != y).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Expect(fNil() == nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Expect(nil == fNil()).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(fNil() == nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Expect(nil == fNil()).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Expect(fNotNil() != nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Expect(nil != fNotNil()).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(fNotNil() != nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Expect(nil != fNotNil()).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 		})
@@ -548,148 +548,148 @@ var _ = Describe("", func() {
 		Context("test Should", func() {
 			Context("test BeTrue", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x == nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == x).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x == nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y != nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != y).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y != nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() == nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNil()).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() == nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() != nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNotNil()).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() != nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test BeFalse", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x != nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != x).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x != nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y == nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == y).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y == nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() != nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNil()).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() != nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() == nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNotNil()).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() == nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(true)", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x == nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == x).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x == nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y != nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != y).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y != nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() == nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNil()).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() == nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() != nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNotNil()).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() != nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(false)", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x != nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != x).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x != nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y == nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == y).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y == nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() != nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNil()).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() != nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() == nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNotNil()).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() == nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 		})
 		Context("test Should(Not())", func() {
 			Context("test BeTrue", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x == nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == x).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x == nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y != nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != y).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y != nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() == nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNil()).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() == nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() != nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNotNil()).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() != nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test BeFalse", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x != nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != x).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x != nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y == nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == y).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y == nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() != nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNil()).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() != nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() == nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNotNil()).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() == nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(false)", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x == nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == x).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x == nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y != nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != y).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y != nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() == nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNil()).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() == nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() != nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNotNil()).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() != nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(true)", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x != nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != x).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x != nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y == nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == y).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y == nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() != nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNil()).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() != nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() == nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNotNil()).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() == nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 		})
@@ -697,148 +697,148 @@ var _ = Describe("", func() {
 		Context("test To", func() {
 			Context("test BeTrue", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x == nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == x).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x == nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y != nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != y).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y != nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() == nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNil()).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() == nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() != nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNotNil()).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() != nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test BeFalse", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x != nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != x).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x != nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y == nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == y).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y == nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() != nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNil()).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() != nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() == nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNotNil()).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() == nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(true)", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x == nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == x).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x == nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y != nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != y).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y != nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() == nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNil()).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() == nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() != nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNotNil()).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() != nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(false)", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x != nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != x).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x != nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y == nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == y).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y == nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() != nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNil()).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() != nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() == nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNotNil()).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() == nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 		})
 		Context("test To(Not())", func() {
 			Context("test BeTrue", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x == nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == x).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x == nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y != nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != y).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y != nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() == nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNil()).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() == nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() != nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNotNil()).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() != nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test BeFalse", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x != nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != x).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x != nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y == nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == y).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y == nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() != nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNil()).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() != nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() == nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNotNil()).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() == nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(false)", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x == nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == x).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x == nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y != nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != y).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y != nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() == nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNil()).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() == nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() != nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNotNil()).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() != nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(true)", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x != nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != x).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x != nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y == nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == y).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y == nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() != nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNil()).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() != nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() == nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNotNil()).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() == nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 		})
@@ -846,74 +846,74 @@ var _ = Describe("", func() {
 		Context("test ShouldNot", func() {
 			Context("test BeFalse", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x == nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == x).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x == nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y != nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != y).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y != nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() == nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNil()).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() == nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() != nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNotNil()).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() != nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test BeTrue", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x != nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != x).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x != nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y == nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == y).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y == nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() != nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNil()).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() != nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() == nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNotNil()).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() == nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(true)", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x != nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != x).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x != nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y == nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == y).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y == nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() != nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNil()).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() != nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() == nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNotNil()).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() == nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(false)", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x == nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == x).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x == nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y != nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != y).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y != nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() == nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNil()).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() == nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() != nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNotNil()).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() != nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 		})
@@ -921,148 +921,148 @@ var _ = Describe("", func() {
 		Context("test NotTo", func() {
 			Context("test BeFalse", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x == nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == x).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x == nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y != nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != y).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y != nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() == nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNil()).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() == nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() != nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNotNil()).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() != nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test BeTrue", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x != nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != x).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x != nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y == nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.NotTo\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == y).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.NotTo\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y == nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.NotTo\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.NotTo\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() != nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNil()).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() != nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() == nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNotNil()).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() == nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(true)", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x != nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != x).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x != nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y == nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.NotTo\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == y).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.NotTo\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y == nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.NotTo\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.NotTo\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() != nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNil()).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() != nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() == nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNotNil()).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() == nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(false)", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x == nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == x).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x == nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y != nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != y).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y != nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() == nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNil()).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() == nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() != nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNotNil()).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() != nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 		})
 		Context("test ToNot", func() {
 			Context("test BeFalse", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x == nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == x).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x == nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y != nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != y).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y != nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() == nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNil()).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() == nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() != nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNotNil()).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() != nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test BeTrue", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x != nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != x).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x != nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y == nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == y).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y == nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() != nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNil()).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() != nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() == nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNotNil()).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() == nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(true)", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x != nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != x).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x != nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != x).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y == nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == y).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y == nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == y).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() != nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNil()).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() != nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNil()).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() == nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNotNil()).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() == nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNotNil()).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(false)", func() {
 				It("test nil value", func() {
-					ExpectWithOffset(1, x == nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == x).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, x == nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == x).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					ExpectWithOffset(1, y != nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != y).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, y != nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != y).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					ExpectWithOffset(1, fNil() == nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil == fNil()).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNil() == nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil == fNil()).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					ExpectWithOffset(1, fNotNil() != nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					ExpectWithOffset(1, nil != fNotNil()).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, fNotNil() != nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					ExpectWithOffset(1, nil != fNotNil()).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .ExpectWithOffset\(1, fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 		})
@@ -1072,148 +1072,148 @@ var _ = Describe("", func() {
 		Context("test Should", func() {
 			Context("test BeTrue", func() {
 				It("test nil value", func() {
-					Ω(x == nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil == x).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(x == nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil == x).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y != nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil != y).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(y != nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil != y).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() == nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil == fNil()).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(fNil() == nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil == fNil()).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() != nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil != fNotNil()).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() != nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil != fNotNil()).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test BeFalse", func() {
 				It("test nil value", func() {
-					Ω(x != nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil != x).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(x != nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil != x).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y == nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil == y).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(y == nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil == y).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() != nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil != fNil()).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(fNil() != nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil != fNil()).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() == nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil == fNotNil()).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() == nil).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil == fNotNil()).Should(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(true)", func() {
 				It("test nil value", func() {
-					Ω(x == nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil == x).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(x == nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil == x).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y != nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil != y).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(y != nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil != y).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() == nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil == fNil()).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(fNil() == nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil == fNil()).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() != nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil != fNotNil()).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() != nil).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil != fNotNil()).Should(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(false)", func() {
 				It("test nil value", func() {
-					Ω(x != nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil != x).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(x != nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil != x).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y == nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil == y).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(y == nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil == y).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() != nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil != fNil()).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(fNil() != nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil != fNil()).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() == nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil == fNotNil()).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() == nil).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil == fNotNil()).Should(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 		})
 		Context("test Should(Not())", func() {
 			Context("test BeTrue", func() {
 				It("test nil value", func() {
-					Ω(x == nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil == x).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(x == nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil == x).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y != nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil != y).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(y != nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil != y).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() == nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil == fNil()).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(fNil() == nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil == fNil()).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() != nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil != fNotNil()).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() != nil).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil != fNotNil()).Should(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test BeFalse", func() {
 				It("test nil value", func() {
-					Ω(x != nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil != x).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(x != nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil != x).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y == nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil == y).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(y == nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil == y).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() != nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil != fNil()).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(fNil() != nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil != fNil()).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() == nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil == fNotNil()).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() == nil).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil == fNotNil()).Should(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(false)", func() {
 				It("test nil value", func() {
-					Ω(x == nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil == x).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(x == nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil == x).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y != nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil != y).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(y != nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil != y).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() == nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil == fNil()).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(fNil() == nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil == fNil()).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() != nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil != fNotNil()).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() != nil).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil != fNotNil()).Should(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(true)", func() {
 				It("test nil value", func() {
-					Ω(x != nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil != x).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(x != nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil != x).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y == nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil == y).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(y == nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil == y).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() != nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil != fNil()).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(fNil() != nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil != fNil()).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() == nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil == fNotNil()).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() == nil).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil == fNotNil()).Should(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 		})
@@ -1221,148 +1221,148 @@ var _ = Describe("", func() {
 		Context("test To", func() {
 			Context("test BeTrue", func() {
 				It("test nil value", func() {
-					Ω(x == nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
-					Ω(nil == x).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(x == nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(nil == x).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y != nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil != y).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(y != nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil != y).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() == nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Ω(nil == fNil()).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(fNil() == nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(nil == fNil()).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() != nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil != fNotNil()).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() != nil).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil != fNotNil()).To(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test BeFalse", func() {
 				It("test nil value", func() {
-					Ω(x != nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
-					Ω(nil != x).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(x != nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(nil != x).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y == nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil == y).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(y == nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil == y).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() != nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Ω(nil != fNil()).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(fNil() != nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(nil != fNil()).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() == nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil == fNotNil()).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() == nil).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil == fNotNil()).To(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(true)", func() {
 				It("test nil value", func() {
-					Ω(x == nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
-					Ω(nil == x).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(x == nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(nil == x).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y != nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil != y).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(y != nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil != y).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() == nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Ω(nil == fNil()).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(fNil() == nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(nil == fNil()).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() != nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil != fNotNil()).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() != nil).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil != fNotNil()).To(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(false)", func() {
 				It("test nil value", func() {
-					Ω(x != nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
-					Ω(nil != x).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(x != nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(nil != x).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y == nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil == y).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(y == nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil == y).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() != nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Ω(nil != fNil()).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(fNil() != nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(nil != fNil()).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() == nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil == fNotNil()).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() == nil).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil == fNotNil()).To(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 		})
 		Context("test To(Not())", func() {
 			Context("test BeTrue", func() {
 				It("test nil value", func() {
-					Ω(x == nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
-					Ω(nil == x).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(x == nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(nil == x).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y != nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil != y).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(y != nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil != y).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() == nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Ω(nil == fNil()).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(fNil() == nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(nil == fNil()).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() != nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil != fNotNil()).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() != nil).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil != fNotNil()).To(Not(BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test BeFalse", func() {
 				It("test nil value", func() {
-					Ω(x != nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
-					Ω(nil != x).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(x != nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(nil != x).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y == nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil == y).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(y == nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil == y).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() != nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Ω(nil != fNil()).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(fNil() != nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(nil != fNil()).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() == nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil == fNotNil()).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() == nil).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil == fNotNil()).To(Not(BeTrue())) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(false)", func() {
 				It("test nil value", func() {
-					Ω(x == nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
-					Ω(nil == x).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(x == nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(nil == x).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y != nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil != y).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(y != nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil != y).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() == nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Ω(nil == fNil()).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(fNil() == nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(nil == fNil()).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() != nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil != fNotNil()).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() != nil).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil != fNotNil()).To(Not(Equal(false))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(true)", func() {
 				It("test nil value", func() {
-					Ω(x != nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
-					Ω(nil != x).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(x != nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(nil != x).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y == nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil == y).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(y == nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil == y).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() != nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Ω(nil != fNil()).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(fNil() != nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(nil != fNil()).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() == nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil == fNotNil()).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() == nil).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil == fNotNil()).To(Not(Equal(true))) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 		})
@@ -1370,74 +1370,74 @@ var _ = Describe("", func() {
 		Context("test ShouldNot", func() {
 			Context("test BeFalse", func() {
 				It("test nil value", func() {
-					Ω(x == nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil == x).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(x == nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil == x).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y != nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil != y).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(y != nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil != y).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() == nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil == fNil()).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(fNil() == nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil == fNil()).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() != nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil != fNotNil()).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() != nil).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil != fNotNil()).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test BeTrue", func() {
 				It("test nil value", func() {
-					Ω(x != nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil != x).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(x != nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil != x).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y == nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil == y).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(y == nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil == y).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() != nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil != fNil()).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(fNil() != nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil != fNil()).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() == nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil == fNotNil()).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() == nil).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil == fNotNil()).ShouldNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(true)", func() {
 				It("test nil value", func() {
-					Ω(x != nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil != x).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(x != nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil != x).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y == nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil == y).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(y == nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil == y).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() != nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil != fNil()).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(fNil() != nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil != fNil()).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() == nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil == fNotNil()).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() == nil).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil == fNotNil()).ShouldNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(false)", func() {
 				It("test nil value", func() {
-					Ω(x == nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil == x).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(x == nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil == x).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y != nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil != y).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(y != nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil != y).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() == nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
-					Ω(nil == fNil()).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(fNil() == nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
+					Ω(nil == fNil()).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() != nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
-					Ω(nil != fNotNil()).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() != nil).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
+					Ω(nil != fNotNil()).ShouldNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ShouldNot\(BeNil\(\)\). instead`
 				})
 			})
 		})
@@ -1445,148 +1445,148 @@ var _ = Describe("", func() {
 		Context("test NotTo", func() {
 			Context("test BeFalse", func() {
 				It("test nil value", func() {
-					Ω(x == nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
-					Ω(nil == x).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(x == nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(nil == x).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y != nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil != y).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(y != nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil != y).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() == nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Ω(nil == fNil()).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(fNil() == nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(nil == fNil()).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() != nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil != fNotNil()).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() != nil).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil != fNotNil()).NotTo(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test BeTrue", func() {
 				It("test nil value", func() {
-					Ω(x != nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
-					Ω(nil != x).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(x != nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(nil != x).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y == nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.NotTo\(BeNil\(\)\). instead`
-					Ω(nil == y).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.NotTo\(BeNil\(\)\). instead`
+					Ω(y == nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.NotTo\(BeNil\(\)\). instead`
+					Ω(nil == y).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.NotTo\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() != nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Ω(nil != fNil()).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(fNil() != nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(nil != fNil()).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() == nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
-					Ω(nil == fNotNil()).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
+					Ω(fNotNil() == nil).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
+					Ω(nil == fNotNil()).NotTo(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(true)", func() {
 				It("test nil value", func() {
-					Ω(x != nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
-					Ω(nil != x).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(x != nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(nil != x).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y == nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.NotTo\(BeNil\(\)\). instead`
-					Ω(nil == y).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.NotTo\(BeNil\(\)\). instead`
+					Ω(y == nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.NotTo\(BeNil\(\)\). instead`
+					Ω(nil == y).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.NotTo\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() != nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Ω(nil != fNil()).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(fNil() != nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(nil != fNil()).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() == nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
-					Ω(nil == fNotNil()).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
+					Ω(fNotNil() == nil).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
+					Ω(nil == fNotNil()).NotTo(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.NotTo\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(false)", func() {
 				It("test nil value", func() {
-					Ω(x == nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
-					Ω(nil == x).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(x == nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(nil == x).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y != nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil != y).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(y != nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil != y).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() == nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Ω(nil == fNil()).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(fNil() == nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(nil == fNil()).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() != nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil != fNotNil()).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() != nil).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil != fNotNil()).NotTo(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 		})
 		Context("test ToNot", func() {
 			Context("test BeFalse", func() {
 				It("test nil value", func() {
-					Ω(x == nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
-					Ω(nil == x).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(x == nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(nil == x).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y != nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil != y).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(y != nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil != y).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() == nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Ω(nil == fNil()).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(fNil() == nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(nil == fNil()).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() != nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil != fNotNil()).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() != nil).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil != fNotNil()).ToNot(BeFalse()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test BeTrue", func() {
 				It("test nil value", func() {
-					Ω(x != nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
-					Ω(nil != x).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(x != nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(nil != x).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y == nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil == y).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(y == nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil == y).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() != nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Ω(nil != fNil()).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(fNil() != nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(nil != fNil()).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() == nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil == fNotNil()).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() == nil).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil == fNotNil()).ToNot(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(true)", func() {
 				It("test nil value", func() {
-					Ω(x != nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
-					Ω(nil != x).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(x != nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(nil != x).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y == nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil == y).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(y == nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil == y).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() != nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Ω(nil != fNil()).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(fNil() != nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(nil != fNil()).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() == nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil == fNotNil()).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() == nil).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil == fNotNil()).ToNot(Equal(true)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 			Context("test Equal(false)", func() {
 				It("test nil value", func() {
-					Ω(x == nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
-					Ω(nil == x).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(x == nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
+					Ω(nil == x).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(x\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
-					Ω(y != nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil != y).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(y != nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil != y).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(y\)\.ToNot\(BeNil\(\)\). instead`
 				})
 				It("test nil func", func() {
-					Ω(fNil() == nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
-					Ω(nil == fNil()).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(fNil() == nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
+					Ω(nil == fNil()).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNil\(\)\)\.To\(BeNil\(\)\). instead`
 				})
 				It("test non-nil func", func() {
-					Ω(fNotNil() != nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
-					Ω(nil != fNotNil()).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion; consider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(fNotNil() != nil).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
+					Ω(nil != fNotNil()).ToNot(Equal(false)) // want `ginkgo-linter: wrong nil assertion\nconsider using .Ω\(fNotNil\(\)\)\.ToNot\(BeNil\(\)\). instead`
 				})
 			})
 		})

--- a/testdata/src/a/nodotimport/a.go
+++ b/testdata/src/a/nodotimport/a.go
@@ -8,27 +8,27 @@ import (
 var _ = ginkgo.Describe("no dot import", func() {
 	ginkgo.It("should trigger length warning", func() {
 		const length = 3
-		gomega.Expect(len("abc")).Should(gomega.Equal(3))               // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.Should\(gomega\.HaveLen\(3\)\). instead`
-		gomega.Expect(len("abc")).Should(gomega.Not(gomega.Equal(4)))   // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.ShouldNot\(gomega\.HaveLen\(4\)\). instead`
-		gomega.Expect(len("abc")).Should(gomega.Equal(length))          // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.Should\(gomega\.HaveLen\(length\)\). instead`
-		gomega.Expect(len("")).Should(gomega.Equal(0))                  // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\(""\)\.Should\(gomega\.BeEmpty\(\)\). instead`
-		gomega.Expect(len("abc")).ShouldNot(gomega.BeZero())            // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.ShouldNot\(gomega\.BeEmpty\(\)\). instead`
-		gomega.Expect(len("abc")).Should(gomega.BeNumerically(">", 0))  // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.ShouldNot\(gomega\.BeEmpty\(\)\). instead`
-		gomega.Expect(len("abc")).Should(gomega.BeNumerically("==", 3)) // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.Should\(gomega\.HaveLen\(3\)\). instead`
+		gomega.Expect(len("abc")).Should(gomega.Equal(3))               // want `ginkgo-linter: wrong length assertion\nconsider using .gomega\.Expect\("abc"\)\.Should\(gomega\.HaveLen\(3\)\). instead`
+		gomega.Expect(len("abc")).Should(gomega.Not(gomega.Equal(4)))   // want `ginkgo-linter: wrong length assertion\nconsider using .gomega\.Expect\("abc"\)\.ShouldNot\(gomega\.HaveLen\(4\)\). instead`
+		gomega.Expect(len("abc")).Should(gomega.Equal(length))          // want `ginkgo-linter: wrong length assertion\nconsider using .gomega\.Expect\("abc"\)\.Should\(gomega\.HaveLen\(length\)\). instead`
+		gomega.Expect(len("")).Should(gomega.Equal(0))                  // want `ginkgo-linter: wrong length assertion\nconsider using .gomega\.Expect\(""\)\.Should\(gomega\.BeEmpty\(\)\). instead`
+		gomega.Expect(len("abc")).ShouldNot(gomega.BeZero())            // want `ginkgo-linter: wrong length assertion\nconsider using .gomega\.Expect\("abc"\)\.ShouldNot\(gomega\.BeEmpty\(\)\). instead`
+		gomega.Expect(len("abc")).Should(gomega.BeNumerically(">", 0))  // want `ginkgo-linter: wrong length assertion\nconsider using .gomega\.Expect\("abc"\)\.ShouldNot\(gomega\.BeEmpty\(\)\). instead`
+		gomega.Expect(len("abc")).Should(gomega.BeNumerically("==", 3)) // want `ginkgo-linter: wrong length assertion\nconsider using .gomega\.Expect\("abc"\)\.Should\(gomega\.HaveLen\(3\)\). instead`
 	})
 	ginkgo.It("should trigger nil warning", func() {
 		var x *int
-		gomega.Expect(x == nil).Should(gomega.Equal(true))           // want `ginkgo-linter: wrong nil assertion; consider using .gomega\.Expect\(x\)\.Should\(gomega\.BeNil\(\)\). instead`
-		gomega.Expect(x == nil).ShouldNot(gomega.Equal(false))       // want `ginkgo-linter: wrong nil assertion; consider using .gomega\.Expect\(x\)\.Should\(gomega\.BeNil\(\)\). instead`
-		gomega.Expect(nil == x).Should(gomega.BeTrue())              // want `ginkgo-linter: wrong nil assertion; consider using .gomega\.Expect\(x\)\.Should\(gomega\.BeNil\(\)\). instead`
-		gomega.Expect(x == nil).ShouldNot(gomega.BeFalse())          // want `ginkgo-linter: wrong nil assertion; consider using .gomega\.Expect\(x\)\.Should\(gomega\.BeNil\(\)\). instead`
-		gomega.Expect(x == nil).Should(gomega.Not(gomega.BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .gomega\.Expect\(x\)\.Should\(gomega\.BeNil\(\)\). instead`
+		gomega.Expect(x == nil).Should(gomega.Equal(true))           // want `ginkgo-linter: wrong nil assertion\nconsider using .gomega\.Expect\(x\)\.Should\(gomega\.BeNil\(\)\). instead`
+		gomega.Expect(x == nil).ShouldNot(gomega.Equal(false))       // want `ginkgo-linter: wrong nil assertion\nconsider using .gomega\.Expect\(x\)\.Should\(gomega\.BeNil\(\)\). instead`
+		gomega.Expect(nil == x).Should(gomega.BeTrue())              // want `ginkgo-linter: wrong nil assertion\nconsider using .gomega\.Expect\(x\)\.Should\(gomega\.BeNil\(\)\). instead`
+		gomega.Expect(x == nil).ShouldNot(gomega.BeFalse())          // want `ginkgo-linter: wrong nil assertion\nconsider using .gomega\.Expect\(x\)\.Should\(gomega\.BeNil\(\)\). instead`
+		gomega.Expect(x == nil).Should(gomega.Not(gomega.BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .gomega\.Expect\(x\)\.Should\(gomega\.BeNil\(\)\). instead`
 	})
 	ginkgo.It("should trigger equal nil warning", func() {
 		var x *int
 		var y = 5
 		var py = &y
-		gomega.Expect(x).Should(gomega.Equal(nil))              // want `ginkgo-linter: wrong nil assertion; consider using .gomega\.Expect\(x\)\.Should\(gomega\.BeNil\(\)\). instead`
-		gomega.Expect(py).Should(gomega.Not(gomega.Equal(nil))) // want `ginkgo-linter: wrong nil assertion; consider using .gomega\.Expect\(py\)\.ShouldNot\(gomega\.BeNil\(\)\). instead`
+		gomega.Expect(x).Should(gomega.Equal(nil))              // want `ginkgo-linter: wrong nil assertion\nconsider using .gomega\.Expect\(x\)\.Should\(gomega\.BeNil\(\)\). instead`
+		gomega.Expect(py).Should(gomega.Not(gomega.Equal(nil))) // want `ginkgo-linter: wrong nil assertion\nconsider using .gomega\.Expect\(py\)\.ShouldNot\(gomega\.BeNil\(\)\). instead`
 	})
 })

--- a/testdata/src/a/nodotimport/b.go
+++ b/testdata/src/a/nodotimport/b.go
@@ -8,19 +8,19 @@ import (
 var _ = g1.Describe("no dot import", func() {
 	g1.It("should ignore length warning", func() {
 		const length = 3
-		g2.Expect(len("abc")).Should(g2.Equal(3))               // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\("abc"\)\.Should\(g2\.HaveLen\(3\)\). instead`
-		g2.Expect(len("abc")).Should(g2.Equal(length))          // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\("abc"\)\.Should\(g2\.HaveLen\(length\)\). instead`
-		g2.Expect(len("")).Should(g2.Equal(0))                  // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\(""\)\.Should\(g2\.BeEmpty\(\)\). instead`
-		g2.Expect(len("abc")).ShouldNot(g2.BeZero())            // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\("abc"\)\.ShouldNot\(g2\.BeEmpty\(\)\). instead`
-		g2.Expect(len("abc")).Should(g2.BeNumerically(">", 0))  // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\("abc"\)\.ShouldNot\(g2\.BeEmpty\(\)\). instead`
-		g2.Expect(len("abc")).Should(g2.BeNumerically("==", 3)) // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\("abc"\).Should\(g2\.HaveLen\(3\)\). instead`
+		g2.Expect(len("abc")).Should(g2.Equal(3))               // want `ginkgo-linter: wrong length assertion\nconsider using .g2\.Expect\("abc"\)\.Should\(g2\.HaveLen\(3\)\). instead`
+		g2.Expect(len("abc")).Should(g2.Equal(length))          // want `ginkgo-linter: wrong length assertion\nconsider using .g2\.Expect\("abc"\)\.Should\(g2\.HaveLen\(length\)\). instead`
+		g2.Expect(len("")).Should(g2.Equal(0))                  // want `ginkgo-linter: wrong length assertion\nconsider using .g2\.Expect\(""\)\.Should\(g2\.BeEmpty\(\)\). instead`
+		g2.Expect(len("abc")).ShouldNot(g2.BeZero())            // want `ginkgo-linter: wrong length assertion\nconsider using .g2\.Expect\("abc"\)\.ShouldNot\(g2\.BeEmpty\(\)\). instead`
+		g2.Expect(len("abc")).Should(g2.BeNumerically(">", 0))  // want `ginkgo-linter: wrong length assertion\nconsider using .g2\.Expect\("abc"\)\.ShouldNot\(g2\.BeEmpty\(\)\). instead`
+		g2.Expect(len("abc")).Should(g2.BeNumerically("==", 3)) // want `ginkgo-linter: wrong length assertion\nconsider using .g2\.Expect\("abc"\).Should\(g2\.HaveLen\(3\)\). instead`
 	})
 	g1.It("should trigger nil warning", func() {
 		var x *int
-		g2.Expect(x == nil).Should(g2.Equal(true))       // want `ginkgo-linter: wrong nil assertion; consider using .g2\.Expect\(x\)\.Should\(g2\.BeNil\(\)\). instead`
-		g2.Expect(x == nil).ShouldNot(g2.Equal(false))   // want `ginkgo-linter: wrong nil assertion; consider using .g2\.Expect\(x\)\.Should\(g2\.BeNil\(\)\). instead`
-		g2.Expect(nil == x).Should(g2.BeTrue())          // want `ginkgo-linter: wrong nil assertion; consider using .g2\.Expect\(x\)\.Should\(g2\.BeNil\(\)\). instead`
-		g2.Expect(x == nil).ShouldNot(g2.BeFalse())      // want `ginkgo-linter: wrong nil assertion; consider using .g2\.Expect\(x\)\.Should\(g2\.BeNil\(\)\). instead`
-		g2.Expect(x == nil).Should(g2.Not(g2.BeFalse())) // want `ginkgo-linter: wrong nil assertion; consider using .g2\.Expect\(x\)\.Should\(g2\.BeNil\(\)\). instead`
+		g2.Expect(x == nil).Should(g2.Equal(true))       // want `ginkgo-linter: wrong nil assertion\nconsider using .g2\.Expect\(x\)\.Should\(g2\.BeNil\(\)\). instead`
+		g2.Expect(x == nil).ShouldNot(g2.Equal(false))   // want `ginkgo-linter: wrong nil assertion\nconsider using .g2\.Expect\(x\)\.Should\(g2\.BeNil\(\)\). instead`
+		g2.Expect(nil == x).Should(g2.BeTrue())          // want `ginkgo-linter: wrong nil assertion\nconsider using .g2\.Expect\(x\)\.Should\(g2\.BeNil\(\)\). instead`
+		g2.Expect(x == nil).ShouldNot(g2.BeFalse())      // want `ginkgo-linter: wrong nil assertion\nconsider using .g2\.Expect\(x\)\.Should\(g2\.BeNil\(\)\). instead`
+		g2.Expect(x == nil).Should(g2.Not(g2.BeFalse())) // want `ginkgo-linter: wrong nil assertion\nconsider using .g2\.Expect\(x\)\.Should\(g2\.BeNil\(\)\). instead`
 	})
 })

--- a/testdata/src/a/sprintfmsg/sprintfmsg.go
+++ b/testdata/src/a/sprintfmsg/sprintfmsg.go
@@ -1,0 +1,41 @@
+package sprintfmsg
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSprintfMsg(t *testing.T) {
+	g := NewWithT(t)
+	s := "hello"
+	g.Expect(s).To(Equal("hello"), `the error is that "%s" is not equal "%s"`, s, "hello")
+	g.Expect(s).To(Equal("hello"), fmt.Sprintf(`the error is that "%s" is not equal "%s"`, s, "hello")) // want `ginkgo-linter: the assertion method is a format function. no need to use Sprintf\nconsider using .g\.Expect\(s\)\.To\(Equal\("hello"\), .the error is that "%s" is not equal "%s"., s, "hello"\). instead`
+
+	//both
+	g.Expect(len(s)).To(Equal(5), fmt.Sprintf(`the error is that "%s" is not with length of %d`, s, 5)) // want `ginkgo-linter: wrong length assertion\nalso, the assertion method is a format function. no need to use Sprintf\nconsider using .g\.Expect\(s\)\.To\(HaveLen\(5\), .the error is that "%s" is not with length of %d., s, 5\). instead`
+}
+
+var _ = Describe("test with ginkgo", func() {
+	It("should warn about Sprintf in assertion description", func() {
+		s := "a"
+		Expect(s).Should(HaveLen(1), fmt.Sprintf("'%s' should have len of 1", s)) // want `ginkgo-linter: the assertion method is a format function\. no need to use Sprintf\nconsider using .Expect\(s\)\.Should\(HaveLen\(1\), "'%s' should have len of 1", s\). instead`
+	})
+
+	It("should warn about length assertion + Sprintf in assertion description", func() {
+		s := "a"
+		Expect(len(s)).Should(Equal(1), fmt.Sprintf("'%s' should have len of 1", s)) // want `ginkgo-linter: wrong length assertion\nalso, the assertion method is a format function\. no need to use Sprintf\nconsider using .Expect\(s\)\.Should\(HaveLen\(1\), "'%s' should have len of 1", s\). instead`
+	})
+
+	It("should warn about nil assertion + Sprintf in assertion description", func() {
+		var s *int
+		Expect(s == nil).Should(Equal(true), fmt.Sprintf("'%v' should be nil", s)) // want `ginkgo-linter: wrong nil assertion\nalso, the assertion method is a format function\. no need to use Sprintf\nconsider using .Expect\(s\)\.Should\(BeNil\(\), "'%v' should be nil", s\). instead`
+	})
+
+	It("should warn about error assertion + Sprintf in assertion description", func() {
+		var err error
+		Expect(err).To(BeNil(), fmt.Sprintf("%v error should be nil", err)) // want `ginkgo-linter: wrong error assertion\nalso, the assertion method is a format function\. no need to use Sprintf\nconsider using .Expect\(err\)\.ToNot\(HaveOccurred\(\), "%v error should be nil", err\). instead`
+	})
+})

--- a/testdata/src/a/sprintfmsg/sprintfmsgwithdifferentname.go
+++ b/testdata/src/a/sprintfmsg/sprintfmsgwithdifferentname.go
@@ -1,0 +1,38 @@
+package sprintfmsg
+
+import (
+	myfmt "fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSprintfMsgWithDifferentName(t *testing.T) {
+	g := NewWithT(t)
+	s := "hello"
+	g.Expect(s).To(Equal("hello"), `the error is that "%s" is not equal "%s"`, s, "hello")
+	g.Expect(s).To(Equal("hello"), myfmt.Sprintf(`the error is that "%s" is not equal "%s"`, s, "hello")) // want `ginkgo-linter: the assertion method is a format function. no need to use Sprintf\nconsider using .g\.Expect\(s\)\.To\(Equal\("hello"\), .the error is that "%s" is not equal "%s"., s, "hello"\). instead`
+}
+
+var _ = Describe("test with ginkgo", func() {
+	It("should warn about Sprintf in assertion description", func() {
+		s := "a"
+		Expect(s).Should(HaveLen(1), myfmt.Sprintf("'%s' should have len of 1", s)) // want `ginkgo-linter: the assertion method is a format function\. no need to use Sprintf\nconsider using .Expect\(s\)\.Should\(HaveLen\(1\), "'%s' should have len of 1", s\). instead`
+	})
+
+	It("should warn about length assertion + Sprintf in assertion description", func() {
+		s := "a"
+		Expect(len(s)).Should(Equal(1), myfmt.Sprintf("'%s' should have len of 1", s)) // want `ginkgo-linter: wrong length assertion\nalso, the assertion method is a format function\. no need to use Sprintf\nconsider using .Expect\(s\)\.Should\(HaveLen\(1\), "'%s' should have len of 1", s\). instead`
+	})
+
+	It("should warn about nil assertion + Sprintf in assertion description", func() {
+		var s *int
+		Expect(s == nil).Should(Equal(true), myfmt.Sprintf("'%v' should be nil", s)) // want `ginkgo-linter: wrong nil assertion\nalso, the assertion method is a format function\. no need to use Sprintf\nconsider using .Expect\(s\)\.Should\(BeNil\(\), "'%v' should be nil", s\). instead`
+	})
+
+	It("should warn about error assertion + Sprintf in assertion description", func() {
+		var err error
+		Expect(err).To(BeNil(), myfmt.Sprintf("%v error should be nil", err)) // want `ginkgo-linter: wrong error assertion\nalso, the assertion method is a format function\. no need to use Sprintf\nconsider using .Expect\(err\)\.ToNot\(HaveOccurred\(\), "%v error should be nil", err\). instead`
+	})
+})

--- a/testdata/src/a/suppress/a.go
+++ b/testdata/src/a/suppress/a.go
@@ -10,7 +10,7 @@ var _ = Describe("Supress wrong length check", func() {
 		It("should ignore length warning", func() {
 			// ginkgo-linter:ignore-len-assert-warning
 			Expect(len("abc")).Should(Equal(3))
-			Expect(len("abc")).Should(Equal(3)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abc"\)\.Should\(HaveLen\(3\)\). instead`
+			Expect(len("abc")).Should(Equal(3)) // want `ginkgo-linter: wrong length assertion\nconsider using .Expect\("abc"\)\.Should\(HaveLen\(3\)\). instead`
 			Expect("123").To(HaveLen(3))
 			/*
 
@@ -35,7 +35,7 @@ var _ = Describe("Supress wrong length check", func() {
 		It("should ignore length warning", func() {
 			// ginkgo-linter:ignore-nil-assert-warning
 			Expect(x == nil).Should(BeTrue())
-			Expect(x == nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+			Expect(x == nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion\nconsider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
 			Expect(x).To(BeNil())
 			/*
 
@@ -60,7 +60,7 @@ var _ = Describe("Supress wrong length check", func() {
 		It("should ignore error warning", func() {
 			// ginkgo-linter:ignore-err-assert-warning
 			Expect(x).To(BeNil())
-			Expect(x == nil).Should(BeTrue()) // want `ginkgo-linter: wrong error assertion; consider using .Expect\(x\)\.ShouldNot\(HaveOccurred\(\)\). instead`
+			Expect(x == nil).Should(BeTrue()) // want `ginkgo-linter: wrong error assertion\nconsider using .Expect\(x\)\.ShouldNot\(HaveOccurred\(\)\). instead`
 			// ginkgo-linter:ignore-err-assert-warning
 			Expect(x == nil).Should(BeTrue())
 			/*

--- a/types/config.go
+++ b/types/config.go
@@ -14,22 +14,24 @@ const (
 )
 
 type Config struct {
-	SuppressLen   Boolean
-	SuppressNil   Boolean
-	SuppressErr   Boolean
-	AllowHaveLen0 Boolean
+	SuppressLen        Boolean
+	SuppressNil        Boolean
+	SuppressErr        Boolean
+	AllowHaveLen0      Boolean
+	AllowSprintfInDesc Boolean
 }
 
 func (s *Config) AllTrue() bool {
-	return bool(s.SuppressLen && s.SuppressNil && s.SuppressErr)
+	return bool(s.SuppressLen && s.SuppressNil && s.SuppressErr && s.AllowSprintfInDesc)
 }
 
 func (s *Config) Clone() Config {
 	return Config{
-		SuppressLen:   s.SuppressLen,
-		SuppressNil:   s.SuppressNil,
-		SuppressErr:   s.SuppressErr,
-		AllowHaveLen0: s.AllowHaveLen0,
+		SuppressLen:        s.SuppressLen,
+		SuppressNil:        s.SuppressNil,
+		SuppressErr:        s.SuppressErr,
+		AllowHaveLen0:      s.AllowHaveLen0,
+		AllowSprintfInDesc: s.AllowSprintfInDesc,
 	}
 }
 

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -6,9 +6,10 @@ import (
 
 func TestSuppress_AllTrue(t *testing.T) {
 	s := Config{
-		SuppressLen: true,
-		SuppressNil: true,
-		SuppressErr: true,
+		SuppressLen:        true,
+		SuppressNil:        true,
+		SuppressErr:        true,
+		AllowSprintfInDesc: true,
 	}
 
 	if !s.AllTrue() {
@@ -43,9 +44,10 @@ func TestSuppress_AllTrue(t *testing.T) {
 
 func TestSuppress_Clone(t *testing.T) {
 	s := Config{
-		SuppressLen: true,
-		SuppressNil: true,
-		SuppressErr: true,
+		SuppressLen:        true,
+		SuppressNil:        true,
+		SuppressErr:        true,
+		AllowSprintfInDesc: true,
 	}
 
 	clone := s.Clone()


### PR DESCRIPTION
As the gomega assertion methods (`To`, `NotTo` `ToNot`, `Should` and `ShouldNot`) are a formatting functions, that accepts a format string + parameters starting from the 2nd parameter, there is no need to use `fmt.Sprintf` for assertion description.

This PR add an optional rule to warn about using `fmt.Sprintf` as assertion description. It is not enabled by default. Use the `-allow-sprintf=false` flag to enable this rule.

Fixes #48

Not sure this is needed. See discussion in #48

/hold