### PR TITLE
Add new linter rule: avoid comparison assersion

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -41,9 +41,10 @@ jobs:
         cp ginkgolinter testdata/src/a
         cd testdata/src/a
 
-        [[ $(./ginkgolinter ./... 2>&1 | wc -l) == 2103 ]]
-        [[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true ./... 2>&1 | wc -l) == 1371 ]]
-        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true ./... 2>&1 | wc -l) == 628 ]]
-        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true ./... 2>&1 | wc -l) == 126 ]]
-        [[ $(./ginkgolinter --allow-havelen-0=true ./... 2>&1 | wc -l) == 2095 ]]
-        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true ./... 2>&1 | wc -l) == 0 ]]
+        [[ $(./ginkgolinter ./... 2>&1 | wc -l) == 2193 ]]
+        [[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 1373 ]]
+        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 632 ]]
+        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 128 ]]
+        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true ./... 2>&1 | wc -l) == 99 ]]
+        [[ $(./ginkgolinter --allow-havelen-0=true ./... 2>&1 | wc -l) == 2183 ]]
+        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 0 ]]

--- a/ginkgo_linter_test.go
+++ b/ginkgo_linter_test.go
@@ -53,6 +53,10 @@ func TestAllUseCases(t *testing.T) {
 			testName: "check gomaga without ginkgo",
 			testData: "a/gomegaonly",
 		},
+		{
+			testName: "comparison",
+			testData: "a/comparison",
+		},
 	} {
 		t.Run(tc.testName, func(tt *testing.T) {
 			analysistest.Run(tt, analysistest.TestData(), ginkgolinter.NewAnalyzer(), tc.testData)
@@ -82,6 +86,11 @@ func TestFlags(t *testing.T) {
 			flags:    []string{"suppress-err-assertion"},
 		},
 		{
+			testName: "test the suppress-compare-assertion flag",
+			testData: []string{"a/configcompare"},
+			flags:    []string{"suppress-compare-assertion"},
+		},
+		{
 			testName: "test the allow-havelen-0 flag",
 			testData: []string{"a/havelen0config"},
 			flags:    []string{"allow-havelen-0"},
@@ -89,7 +98,7 @@ func TestFlags(t *testing.T) {
 		{
 			testName: "supress all",
 			testData: []string{"a/configlen", "a/confignil", "a/configerr", "a/havelen0config"},
-			flags:    []string{"suppress-len-assertion", "suppress-nil-assertion", "suppress-err-assertion"},
+			flags:    []string{"suppress-len-assertion", "suppress-nil-assertion", "suppress-err-assertion", "suppress-compare-assertion"},
 		},
 	} {
 		t.Run(tc.testName, func(tt *testing.T) {

--- a/reverseassertion/reverse_assertion.go
+++ b/reverseassertion/reverse_assertion.go
@@ -1,5 +1,7 @@
 package reverseassertion
 
+import "go/token"
+
 var reverseLogicAssertions = map[string]string{
 	"To":        "ToNot",
 	"ToNot":     "To",
@@ -14,4 +16,19 @@ func ChangeAssertionLogic(funcName string) string {
 		return revFunc
 	}
 	return funcName
+}
+
+var reverseCompareOperators = map[token.Token]token.Token{
+	token.LSS: token.GTR,
+	token.GTR: token.LSS,
+	token.LEQ: token.GEQ,
+	token.GEQ: token.LEQ,
+}
+
+// ChangeCompareOperator return the reversed comparison operator
+func ChangeCompareOperator(op token.Token) token.Token {
+	if revOp, ok := reverseCompareOperators[op]; ok {
+		return revOp
+	}
+	return op
 }

--- a/reverseassertion/reverse_assertion_test.go
+++ b/reverseassertion/reverse_assertion_test.go
@@ -1,6 +1,7 @@
 package reverseassertion_test
 
 import (
+	"go/token"
 	"testing"
 
 	"github.com/nunnatsa/ginkgolinter/reverseassertion"
@@ -41,5 +42,25 @@ func TestChangeAssertionLogicWithUnknown(t *testing.T) {
 	rev := reverseassertion.ChangeAssertionLogic("unknown")
 	if rev != "unknown" {
 		t.Errorf("reverced function of unknown should be the same, but it's %s", rev)
+	}
+}
+
+func TestChangeCompareOperator(t *testing.T) {
+	for _, tc := range []struct {
+		testName string
+		checked  token.Token
+		expected token.Token
+	}{
+		{"check less than", token.LSS, token.GTR},
+		{"check greater than", token.GTR, token.LSS},
+		{"check less than or equal to", token.LEQ, token.GEQ},
+		{"check greater than or equal to", token.GEQ, token.LEQ},
+		{"check non-supported token", token.ILLEGAL, token.ILLEGAL},
+	} {
+		t.Run(tc.testName, func(tt *testing.T) {
+			if reverseassertion.ChangeCompareOperator(tc.checked) != tc.expected {
+				tt.Errorf("expected %v to become %v", tc.checked, tc.expected)
+			}
+		})
 	}
 }

--- a/testdata/src/a/comparison/comparison.go
+++ b/testdata/src/a/comparison/comparison.go
@@ -1,0 +1,117 @@
+package comparison
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"time"
+)
+
+var exampleInt = 1
+
+const constZero = 0
+const constOne = 1
+const constTwo = 2
+const constStr = "abcd"
+
+var exampleFloat32 float32 = 1
+
+const constFloat32 float32 = 1
+
+var err error
+
+func retNum() int {
+	return 1
+}
+
+var _ = Describe("remove comparison", func() {
+	Context("equal/not equal cases", func() {
+		It("should find comparison assertions", func() {
+			Expect(exampleInt == 0).To(Equal(false)) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\).ToNot\(BeZero\(\)\). instead`
+			Expect(0 == exampleInt).To(Equal(false)) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\).ToNot\(BeZero\(\)\). instead`
+			Expect(exampleInt == 0).To(BeFalse())    // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\).ToNot\(BeZero\(\)\). instead`
+
+			Expect(exampleInt == constZero).To(Equal(false)) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\).ToNot\(BeZero\(\)\). instead`
+			Expect(constZero == exampleInt).To(Equal(false)) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\).ToNot\(BeZero\(\)\). instead`
+			Expect(exampleInt == constZero).To(BeFalse())    // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\).ToNot\(BeZero\(\)\). instead`
+
+			Expect(exampleInt).To(Equal(1))
+			Expect(exampleInt == 1).To(Equal(true))  // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(Equal\(1\)\). instead`
+			Expect(exampleInt != 1).To(Equal(false)) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(Equal\(1\)\). instead`
+
+			Expect(1 == retNum()).To(BeTrue())     // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(retNum\(\)\)\.To\(Equal\(1\)\). instead`
+			Expect(retNum() == 1).To(Equal(true))  // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(retNum\(\)\)\.To\(Equal\(1\)\). instead`
+			Expect(retNum() != 1).To(Equal(false)) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(retNum\(\)\)\.To\(Equal\(1\)\). instead`
+
+			exampleInt = 0
+
+			Expect(exampleInt == 0).To(Equal(true)) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeZero\(\)\). instead`
+			Expect(exampleInt == 0).To(BeTrue())    // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeZero\(\)\). instead`
+		})
+		It("should find comparison assertions", func() {
+			Expect(exampleInt == 1).To(BeTrue())  // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(Equal\(1\)\). instead`
+			Expect(exampleInt != 1).To(BeFalse()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(Equal\(1\)\). instead`
+		})
+		It("should find comparison assertions", func() {
+			Expect(exampleInt == constOne).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(Equal\(constOne\)\). instead`
+		})
+
+		It("should find comparison assertions", func() {
+			Expect(exampleFloat32 == 1).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleFloat32\)\.To\(Equal\(1\)\). instead`
+		})
+		It("should find comparison assertions", func() {
+			Expect(exampleFloat32 == 1.0).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleFloat32\)\.To\(Equal\(1.0\)\). instead`
+		})
+		It("should find comparison assertions", func() {
+			Expect(exampleFloat32 == constOne).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleFloat32\)\.To\(Equal\(constOne\)\). instead`
+		})
+		It("imported const", func() {
+			Expect(time.Millisecond == 1000000).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(time.Millisecond\)\.To\(Equal\(1000000\)\). instead`
+		})
+		It("string const", func() {
+			var s = "abcd"
+			Expect(s == constStr).Should(BeTrue())    // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(s\)\.Should\(Equal\(constStr\)\). instead`
+			Expect(constStr == s).Should(Equal(true)) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(s\)\.Should\(Equal\(constStr\)\). instead`
+		})
+	})
+
+	Context("less than", func() {
+		It("check greater than", func() {
+			Expect(exampleInt > constZero).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\(">", constZero\)\). instead`
+			Expect(constZero < exampleInt).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\(">", constZero\)\). instead`
+			Expect(exampleInt).To(BeNumerically(">", 0))
+			Expect(exampleInt > 0).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\(">", 0\)\). instead`
+			Expect(0 < exampleInt).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\(">", 0\)\). instead`
+
+			Expect(retNum() > constZero).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(retNum\(\)\)\.To\(BeNumerically\(">", constZero\)\). instead`
+			Expect(constZero < retNum()).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(retNum\(\)\)\.To\(BeNumerically\(">", constZero\)\). instead`
+			Expect(retNum()).To(BeNumerically(">", 0))
+			Expect(retNum() > 0).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(retNum\(\)\)\.To\(BeNumerically\(">", 0\)\). instead`
+			Expect(0 < retNum()).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(retNum\(\)\)\.To\(BeNumerically\(">", 0\)\). instead`
+		})
+
+		It("check greater than or equal", func() {
+			Expect(constZero <= exampleInt).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\(">=", constZero\)\). instead`
+			Expect(exampleInt >= constZero).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\(">=", constZero\)\). instead`
+			Expect(exampleInt).To(BeNumerically(">=", 0))
+			Expect(exampleInt >= 0).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\(">=", 0\)\). instead`
+			Expect(0 <= exampleInt).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\(">=", 0\)\). instead`
+		})
+
+		It("check less than", func() {
+			Expect(exampleInt < constTwo).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\("<", constTwo\)\). instead`
+			Expect(constTwo > exampleInt).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\("<", constTwo\)\). instead`
+			Expect(exampleInt).To(BeNumerically("<", 2))
+			Expect(exampleInt < 2).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\("<", 2\)\). instead`
+			Expect(2 > exampleInt).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\("<", 2\)\). instead`
+		})
+
+		It("check less than or equal", func() {
+			Expect(constTwo >= exampleInt).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\("<=", constTwo\)\). instead`
+			Expect(exampleInt <= constTwo).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\("<=", constTwo\)\). instead`
+			Expect(exampleInt).To(BeNumerically("<=", 2))
+			Expect(exampleInt <= 2).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\("<=", 2\)\). instead`
+			Expect(2 >= exampleInt).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\("<=", 2\)\). instead`
+		})
+
+	})
+})

--- a/testdata/src/a/comparison/comparison.gomega.go
+++ b/testdata/src/a/comparison/comparison.gomega.go
@@ -1,0 +1,97 @@
+package comparison
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	g "github.com/onsi/gomega"
+	"time"
+)
+
+var _ = Describe("remove comparison", func() {
+	Context("equal/not equal cases", func() {
+		It("should find comparison assertions", func() {
+			g.Expect(exampleInt == 0).To(g.Equal(false)) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.ToNot\(g\.BeZero\(\)\). instead`
+			g.Expect(0 == exampleInt).To(g.Equal(false)) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.ToNot\(g\.BeZero\(\)\). instead`
+			g.Expect(exampleInt == 0).To(g.BeFalse())    // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.ToNot\(g\.BeZero\(\)\). instead`
+
+			g.Expect(exampleInt == constZero).To(g.Equal(false)) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.ToNot\(g\.BeZero\(\)\). instead`
+			g.Expect(constZero == exampleInt).To(g.Equal(false)) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.ToNot\(g\.BeZero\(\)\). instead`
+			g.Expect(exampleInt == constZero).To(g.BeFalse())    // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.ToNot\(g\.BeZero\(\)\). instead`
+			g.Expect(exampleInt != constZero).To(g.BeTrue())     // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.ToNot\(g\.BeZero\(\)\). instead`
+			g.Expect(constZero != exampleInt).To(g.BeTrue())     // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.ToNot\(g\.BeZero\(\)\). instead`
+
+			g.Expect(exampleInt).To(g.Equal(1))
+			g.Expect(exampleInt == 1).To(g.Equal(true))  // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.Equal\(1\)\). instead`
+			g.Expect(exampleInt != 1).To(g.Equal(false)) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.Equal\(1\)\). instead`
+
+			g.Expect(1 == retNum()).To(g.BeTrue())     // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(retNum\(\)\)\.To\(g\.Equal\(1\)\). instead`
+			g.Expect(retNum() == 1).To(g.Equal(true))  // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(retNum\(\)\)\.To\(g\.Equal\(1\)\). instead`
+			g.Expect(retNum() != 1).To(g.Equal(false)) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(retNum\(\)\)\.To\(g\.Equal\(1\)\). instead`
+
+			exampleInt = 0
+
+			g.Expect(exampleInt == 0).To(g.Equal(true)) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.BeZero\(\)\). instead`
+			g.Expect(exampleInt == 0).To(g.BeTrue())    // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.BeZero\(\)\). instead`
+		})
+		It("should find comparison assertions", func() {
+			g.Expect(exampleInt == 1).To(g.BeTrue())  // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.Equal\(1\)\). instead`
+			g.Expect(exampleInt != 1).To(g.BeFalse()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.Equal\(1\)\). instead`
+		})
+		It("should find comparison assertions", func() {
+			g.Expect(exampleInt == constOne).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.Equal\(constOne\)\). instead`
+		})
+
+		It("should find comparison assertions", func() {
+			g.Expect(exampleFloat32 == 1).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleFloat32\)\.To\(g\.Equal\(1\)\). instead`
+		})
+		It("should find comparison assertions", func() {
+			g.Expect(exampleFloat32 == 1.0).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleFloat32\)\.To\(g\.Equal\(1.0\)\). instead`
+		})
+		It("should find comparison assertions", func() {
+			g.Expect(exampleFloat32 == constOne).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleFloat32\)\.To\(g\.Equal\(constOne\)\). instead`
+		})
+		It("imported const", func() {
+			g.Expect(time.Millisecond == 1000000).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(time.Millisecond\)\.To\(g\.Equal\(1000000\)\). instead`
+		})
+	})
+
+	Context("non-equal comparisons", func() {
+		It("check greater than", func() {
+			g.Expect(exampleInt > constZero).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.BeNumerically\(">", constZero\)\). instead`
+			g.Expect(constZero < exampleInt).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.BeNumerically\(">", constZero\)\). instead`
+			g.Expect(exampleInt).To(g.BeNumerically(">", 0))
+			g.Expect(exampleInt > 0).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.BeNumerically\(">", 0\)\). instead`
+			g.Expect(0 < exampleInt).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.BeNumerically\(">", 0\)\). instead`
+
+			g.Expect(retNum() > constZero).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(retNum\(\)\)\.To\(g\.BeNumerically\(">", constZero\)\). instead`
+			g.Expect(constZero < retNum()).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(retNum\(\)\)\.To\(g\.BeNumerically\(">", constZero\)\). instead`
+			g.Expect(retNum()).To(g.BeNumerically(">", 0))
+			g.Expect(retNum() > 0).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(retNum\(\)\)\.To\(g\.BeNumerically\(">", 0\)\). instead`
+			g.Expect(0 < retNum()).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(retNum\(\)\)\.To\(g\.BeNumerically\(">", 0\)\). instead`
+		})
+
+		It("check greater than or equal", func() {
+			g.Expect(constZero <= exampleInt).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.BeNumerically\(">=", constZero\)\). instead`
+			g.Expect(exampleInt >= constZero).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.BeNumerically\(">=", constZero\)\). instead`
+			g.Expect(exampleInt).To(g.BeNumerically(">=", 0))
+			g.Expect(exampleInt >= 0).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.BeNumerically\(">=", 0\)\). instead`
+			g.Expect(0 <= exampleInt).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.BeNumerically\(">=", 0\)\). instead`
+		})
+
+		It("check less than", func() {
+			g.Expect(exampleInt < constTwo).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.BeNumerically\("<", constTwo\)\). instead`
+			g.Expect(constTwo > exampleInt).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.BeNumerically\("<", constTwo\)\). instead`
+			g.Expect(exampleInt).To(g.BeNumerically("<", 2))
+			g.Expect(exampleInt < 2).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.BeNumerically\("<", 2\)\). instead`
+			g.Expect(2 > exampleInt).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.BeNumerically\("<", 2\)\). instead`
+		})
+
+		It("check less than or equal", func() {
+			g.Expect(constTwo >= exampleInt).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.BeNumerically\("<=", constTwo\)\). instead`
+			g.Expect(exampleInt <= constTwo).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.BeNumerically\("<=", constTwo\)\). instead`
+			g.Expect(exampleInt).To(g.BeNumerically("<=", 2))
+			g.Expect(exampleInt <= 2).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.BeNumerically\("<=", 2\)\). instead`
+			g.Expect(2 >= exampleInt).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.BeNumerically\("<=", 2\)\). instead`
+		})
+
+	})
+})

--- a/testdata/src/a/configcompare/a.go
+++ b/testdata/src/a/configcompare/a.go
@@ -1,0 +1,15 @@
+package configcompare
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("", func() {
+	When("configured to suppress comparison assertion warning", func() {
+		It("should not trigger warning", func() {
+			abcd := "abcd"
+			Expect("abcd" == abcd).To(BeTrue())
+		})
+	})
+})

--- a/testdata/src/a/havelen0/havelen0.go
+++ b/testdata/src/a/havelen0/havelen0.go
@@ -10,9 +10,11 @@ const EMPTY = 0
 var _ = Describe("test HaveLen(0)", func() {
 	It("should replace HaveLen(0) with BeEmpty()", func() {
 		x := make([]int, 0)
-		Expect(x).To(HaveLen(0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(x\)\.To\(BeEmpty\(\)\). instead`
+		Expect(x).To(HaveLen(0))     // want `ginkgo-linter: wrong length assertion; consider using .Expect\(x\)\.To\(BeEmpty\(\)\). instead`
+		Expect(x).To(HaveLen(EMPTY)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(x\)\.To\(BeEmpty\(\)\). instead`
 
 		x = append(x, 1)
-		Expect(x).To(Not(HaveLen(0))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(x\)\.ToNot\(BeEmpty\(\)\). instead`
+		Expect(x).To(Not(HaveLen(0)))     // want `ginkgo-linter: wrong length assertion; consider using .Expect\(x\)\.ToNot\(BeEmpty\(\)\). instead`
+		Expect(x).To(Not(HaveLen(EMPTY))) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(x\)\.ToNot\(BeEmpty\(\)\). instead`
 	})
 })

--- a/testdata/src/a/nil/a.go
+++ b/testdata/src/a/nil/a.go
@@ -1597,10 +1597,5 @@ var _ = Describe("", func() {
 			var x *int
 			Expect(x == nil).To(BeElementOf([]bool{true, false}))
 		})
-
-		It("should not trigger warning", func() {
-			var x = 5
-			Expect(x > 3).To(BeTrue())
-		})
 	})
 })

--- a/testdata/src/a/suppress/coparison.comment.go
+++ b/testdata/src/a/suppress/coparison.comment.go
@@ -1,0 +1,16 @@
+package suppress
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("should suppress comparison assertions", func() {
+	It("should suppress comparison assertions", func() {
+		Expect(len("abcd")).To(Equal(4)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(HaveLen\(4\)\). instead`
+		str := "abcd"
+		// ginkgo-linter:ignore-compare-assert-warning
+		Expect("abcd" == str).To(BeTrue()) // no warning triggered
+		Expect("abcd" == str).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(str\)\.To\(Equal\("abcd"\)\). instead`
+	})
+})

--- a/testdata/src/a/suppress/coparison.file.go
+++ b/testdata/src/a/suppress/coparison.file.go
@@ -1,0 +1,16 @@
+package suppress
+
+// ginkgo-linter:ignore-compare-assert-warning
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("should suppress comparison assertions", func() {
+	It("should suppress comparison assertions", func() {
+		Expect(len("abcd")).To(Equal(4)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.To\(HaveLen\(4\)\). instead`
+		str := "abcd"
+		Expect("abcd" == str).To(BeTrue()) // no warning triggered
+	})
+})

--- a/types/config.go
+++ b/types/config.go
@@ -7,29 +7,32 @@ import (
 )
 
 const (
-	suppressPrefix                 = "ginkgo-linter:"
-	suppressLengthAssertionWarning = suppressPrefix + "ignore-len-assert-warning"
-	suppressNilAssertionWarning    = suppressPrefix + "ignore-nil-assert-warning"
-	suppressErrAssertionWarning    = suppressPrefix + "ignore-err-assert-warning"
+	suppressPrefix                  = "ginkgo-linter:"
+	suppressLengthAssertionWarning  = suppressPrefix + "ignore-len-assert-warning"
+	suppressNilAssertionWarning     = suppressPrefix + "ignore-nil-assert-warning"
+	suppressErrAssertionWarning     = suppressPrefix + "ignore-err-assert-warning"
+	suppressCompareAssertionWarning = suppressPrefix + "ignore-compare-assert-warning"
 )
 
 type Config struct {
-	SuppressLen   Boolean
-	SuppressNil   Boolean
-	SuppressErr   Boolean
-	AllowHaveLen0 Boolean
+	SuppressLen     Boolean
+	SuppressNil     Boolean
+	SuppressErr     Boolean
+	SuppressCompare Boolean
+	AllowHaveLen0   Boolean
 }
 
 func (s *Config) AllTrue() bool {
-	return bool(s.SuppressLen && s.SuppressNil && s.SuppressErr)
+	return bool(s.SuppressLen && s.SuppressNil && s.SuppressErr && s.SuppressCompare)
 }
 
 func (s *Config) Clone() Config {
 	return Config{
-		SuppressLen:   s.SuppressLen,
-		SuppressNil:   s.SuppressNil,
-		SuppressErr:   s.SuppressErr,
-		AllowHaveLen0: s.AllowHaveLen0,
+		SuppressLen:     s.SuppressLen,
+		SuppressNil:     s.SuppressNil,
+		SuppressErr:     s.SuppressErr,
+		SuppressCompare: s.SuppressCompare,
+		AllowHaveLen0:   s.AllowHaveLen0,
 	}
 }
 
@@ -50,6 +53,7 @@ func (s *Config) UpdateFromComment(commentGroup []*ast.CommentGroup) {
 				s.SuppressLen = s.SuppressLen || (comment == suppressLengthAssertionWarning)
 				s.SuppressNil = s.SuppressNil || (comment == suppressNilAssertionWarning)
 				s.SuppressErr = s.SuppressErr || (comment == suppressErrAssertionWarning)
+				s.SuppressCompare = s.SuppressCompare || (comment == suppressCompareAssertionWarning)
 			}
 		}
 	}

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -6,9 +6,10 @@ import (
 
 func TestSuppress_AllTrue(t *testing.T) {
 	s := Config{
-		SuppressLen: true,
-		SuppressNil: true,
-		SuppressErr: true,
+		SuppressLen:     true,
+		SuppressNil:     true,
+		SuppressErr:     true,
+		SuppressCompare: true,
 	}
 
 	if !s.AllTrue() {
@@ -43,9 +44,10 @@ func TestSuppress_AllTrue(t *testing.T) {
 
 func TestSuppress_Clone(t *testing.T) {
 	s := Config{
-		SuppressLen: true,
-		SuppressNil: true,
-		SuppressErr: true,
+		SuppressLen:     true,
+		SuppressNil:     true,
+		SuppressErr:     true,
+		SuppressCompare: true,
 	}
 
 	clone := s.Clone()


### PR DESCRIPTION
# Description
A worng comparison is a boolean comparison using `==', `!=`, `>`, `>=`, `<` or `<=`, and assertion of a boolean value.

Examples:

`Expect(x == 10).Should(BeTrue())` ==> `Expect(x).Should(Equal(10))`

`Expect(s != "testing").Should(Equal(true))` ==> `Expect(s).ShouldNot(Equal("testing"))`

`Expect(x > 10).To(BeTrue())` ==> `Expect(x).To(BeNumerically(">", 10))`

Added a new executable's flag to suppress this new rule: `--suppress-compare-assertion=true`

Fixes #64 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Added test case and related test data
- [x] Update the functional test

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)

@pohly
