### PR TITLE
Fix bug with comparison and pointers

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -41,10 +41,10 @@ jobs:
         cp ginkgolinter testdata/src/a
         cd testdata/src/a
 
-        [[ $(./ginkgolinter ./... 2>&1 | wc -l) == 2193 ]]
+        [[ $(./ginkgolinter ./... 2>&1 | wc -l) == 2205 ]]
         [[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 1373 ]]
         [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 632 ]]
         [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 128 ]]
-        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true ./... 2>&1 | wc -l) == 99 ]]
-        [[ $(./ginkgolinter --allow-havelen-0=true ./... 2>&1 | wc -l) == 2183 ]]
+        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true ./... 2>&1 | wc -l) == 111 ]]
+        [[ $(./ginkgolinter --allow-havelen-0=true ./... 2>&1 | wc -l) == 2195 ]]
         [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 0 ]]

--- a/ginkgo_linter_test.go
+++ b/ginkgo_linter_test.go
@@ -57,6 +57,10 @@ func TestAllUseCases(t *testing.T) {
 			testName: "comparison",
 			testData: "a/comparison",
 		},
+		{
+			testName: "pointers",
+			testData: "a/pointers",
+		},
 	} {
 		t.Run(tc.testName, func(tt *testing.T) {
 			analysistest.Run(tt, analysistest.TestData(), ginkgolinter.NewAnalyzer(), tc.testData)

--- a/testdata/src/a/pointers/pointers.go
+++ b/testdata/src/a/pointers/pointers.go
@@ -1,0 +1,51 @@
+package pointers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type bbber interface {
+	bbb()
+}
+
+type inner struct {
+	i *int
+}
+
+type ttt struct {
+	in *inner
+}
+
+func (*ttt) bbb() {}
+
+func GetBBB() bbber {
+	var i = 8
+	return &ttt{in: &inner{i: &i}}
+}
+
+var _ = Describe("", func() {
+	It("", func() {
+		val1, val2 := 8, 8
+		p1, p2, p3 := &val1, &val1, &val2
+		Expect(p1 == p2).To(BeTrue())  // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(p1\)\.To\(BeIdenticalTo\(p2\)\). instead`
+		Expect(p1 == p3).To(BeFalse()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(p1\)\.ToNot\(BeIdenticalTo\(p3\)\). instead`
+	})
+
+	It("", func() {
+		var (
+			v1 = 8
+			v2 = 8
+		)
+		t1 := &ttt{in: &inner{i: &v1}}
+		t2 := &ttt{in: &inner{i: &v1}}
+		t3 := &ttt{in: &inner{i: &v2}}
+
+		Expect(t1 != t2).To(BeTrue())           // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(t1\)\.ToNot\(BeIdenticalTo\(t2\)\). instead`
+		Expect(t1.in.i == t2.in.i).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(t1.in.i\)\.To\(BeIdenticalTo\(t2.in.i\)\). instead`
+		Expect(t1.in.i != t3.in.i).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(t1.in.i\)\.ToNot\(BeIdenticalTo\(t3.in.i\)\). instead`
+
+		t4 := GetBBB()
+		Expect(t4 == t1).To(BeFalse()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(t4\)\.ToNot\(BeIdenticalTo\(t1\)\). instead`
+	})
+})

--- a/testdata/src/a/pointers/pointers.gomega.go
+++ b/testdata/src/a/pointers/pointers.gomega.go
@@ -1,0 +1,33 @@
+package pointers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	g "github.com/onsi/gomega"
+)
+
+var _ = Describe("", func() {
+	It("", func() {
+		val1, val2 := 8, 8
+		p1, p2, p3 := &val1, &val1, &val2
+		g.Expect(p1 == p2).To(g.BeTrue())  // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(p1\)\.To\(g\.BeIdenticalTo\(p2\)\). instead`
+		g.Expect(p1 == p3).To(g.BeFalse()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(p1\)\.ToNot\(g\.BeIdenticalTo\(p3\)\). instead`
+	})
+
+	It("", func() {
+		var (
+			v1 = 8
+			v2 = 8
+		)
+		t1 := &ttt{in: &inner{i: &v1}}
+		t2 := &ttt{in: &inner{i: &v1}}
+		t3 := &ttt{in: &inner{i: &v2}}
+
+		g.Expect(t1 != t2).To(g.BeTrue())           // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(t1\)\.ToNot\(g\.BeIdenticalTo\(t2\)\). instead`
+		g.Expect(t1.in.i == t2.in.i).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(t1\.in\.i\)\.To\(g\.BeIdenticalTo\(t2\.in\.i\)\). instead`
+		g.Expect(t1.in.i != t3.in.i).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(t1\.in\.i\)\.ToNot\(g\.BeIdenticalTo\(t3\.in\.i\)\). instead`
+
+		t4 := GetBBB()
+		g.Expect(t4 == t1).To(g.BeFalse()) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(t4\)\.ToNot\(g\.BeIdenticalTo\(t1\)\). instead`
+
+	})
+})


### PR DESCRIPTION
# Description
When comapring two pointrs like this:
`Expect(p1 != p2).To(BeTrue())`

For go, it means comparing the
addresses. The linter changes this to

`Expect(p1).ToNot(Equal(p2))`.

But in this case gomega compares the values
pointed by the pointers.

This PR fixes this issue by using the `BeIdenticalTo` matcher in case of pointers coparison.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added test case and related test data
- [x] Update the functional test

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)

@nunnatsa
