### PR TITLE
Support the WithOffset method

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -41,10 +41,10 @@ jobs:
         cp ginkgolinter testdata/src/a
         cd testdata/src/a
 
-        [[ $(./ginkgolinter ./... 2>&1 | wc -l) == 2205 ]]
-        [[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 1373 ]]
-        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 632 ]]
-        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 128 ]]
-        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true ./... 2>&1 | wc -l) == 111 ]]
-        [[ $(./ginkgolinter --allow-havelen-0=true ./... 2>&1 | wc -l) == 2195 ]]
+        [[ $(./ginkgolinter ./... 2>&1 | wc -l) == 2217 ]]
+        [[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 1378 ]]
+        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 638 ]]
+        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 131 ]]
+        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true ./... 2>&1 | wc -l) == 118 ]]
+        [[ $(./ginkgolinter --allow-havelen-0=true ./... 2>&1 | wc -l) == 2205 ]]
         [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 0 ]]

--- a/testdata/src/a/boolean/bool.go
+++ b/testdata/src/a/boolean/bool.go
@@ -12,5 +12,6 @@ var _ = Describe("Equal(true/false)", func() {
 		Expect(t).To(Equal(true))                        // want `ginkgo-linter: wrong boolean assertion; consider using .Expect\(t\)\.To\(BeTrue\(\)\). instead`
 		Expect(f).To(Equal(false))                       // want `ginkgo-linter: wrong boolean assertion; consider using .Expect\(f\)\.To\(BeFalse\(\)\). instead`
 		ExpectWithOffset(2, t).Should(Not(Equal(false))) // want `ginkgo-linter: wrong boolean assertion; consider using .ExpectWithOffset\(2, t\)\.ShouldNot\(BeFalse\(\)\). instead`
+		Expect(f).WithOffset(1).ToNot(Equal(true))       // want `ginkgo-linter: wrong boolean assertion; consider using .Expect\(f\)\.WithOffset\(1\)\.ToNot\(BeTrue\(\)\). instead`
 	})
 })

--- a/testdata/src/a/comparison/comparison.go
+++ b/testdata/src/a/comparison/comparison.go
@@ -44,8 +44,9 @@ var _ = Describe("remove comparison", func() {
 
 			exampleInt = 0
 
-			Expect(exampleInt == 0).To(Equal(true)) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeZero\(\)\). instead`
-			Expect(exampleInt == 0).To(BeTrue())    // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeZero\(\)\). instead`
+			Expect(exampleInt == 0).To(Equal(true))            // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeZero\(\)\). instead`
+			Expect(exampleInt == 0).To(BeTrue())               // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeZero\(\)\). instead`
+			Expect(exampleInt == 0).WithOffset(5).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.WithOffset\(5\)\.To\(BeZero\(\)\). instead`
 		})
 		It("should find comparison assertions", func() {
 			Expect(exampleInt == 1).To(BeTrue())  // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(Equal\(1\)\). instead`

--- a/testdata/src/a/comparison/comparison.gomega.go
+++ b/testdata/src/a/comparison/comparison.gomega.go
@@ -29,8 +29,9 @@ var _ = Describe("remove comparison", func() {
 
 			exampleInt = 0
 
-			g.Expect(exampleInt == 0).To(g.Equal(true)) // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.BeZero\(\)\). instead`
-			g.Expect(exampleInt == 0).To(g.BeTrue())    // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.BeZero\(\)\). instead`
+			g.Expect(exampleInt == 0).To(g.Equal(true))            // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.BeZero\(\)\). instead`
+			g.Expect(exampleInt == 0).To(g.BeTrue())               // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.BeZero\(\)\). instead`
+			g.Expect(exampleInt == 0).WithOffset(5).To(g.BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .g.Expect\(exampleInt\)\.WithOffset\(5\)\.To\(g\.BeZero\(\)\). instead`
 		})
 		It("should find comparison assertions", func() {
 			g.Expect(exampleInt == 1).To(g.BeTrue())  // want `ginkgo-linter: wrong comparison assertion; consider using .g\.Expect\(exampleInt\)\.To\(g\.Equal\(1\)\). instead`

--- a/testdata/src/a/equalnil/a.go
+++ b/testdata/src/a/equalnil/a.go
@@ -10,8 +10,9 @@ var _ = Describe("Check Equal(nil)", func() {
 		var x *int
 		var y = 5
 		var py = &y
-		Expect(x).Should(Equal(nil))                    // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
-		Expect(py).Should(Not(Equal(nil)))              // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(py\)\.ShouldNot\(BeNil\(\)\). instead`
-		ExpectWithOffset(1, py).Should(Not(Equal(nil))) // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, py\)\.ShouldNot\(BeNil\(\)\). instead`
+		Expect(x).Should(Equal(nil))                     // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+		Expect(py).Should(Not(Equal(nil)))               // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(py\)\.ShouldNot\(BeNil\(\)\). instead`
+		ExpectWithOffset(1, py).Should(Not(Equal(nil)))  // want `ginkgo-linter: wrong nil assertion; consider using .ExpectWithOffset\(1, py\)\.ShouldNot\(BeNil\(\)\). instead`
+		Expect(py).WithOffset(1).Should(Not(Equal(nil))) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(py\)\.WithOffset\(1\)\.ShouldNot\(BeNil\(\)\). instead`
 	})
 })

--- a/testdata/src/a/havelen0/gomega.go
+++ b/testdata/src/a/havelen0/gomega.go
@@ -10,7 +10,8 @@ func TestHaveLen0(t *testing.T) {
 	g := NewWithT(t)
 
 	x := make([]int, 0)
-	g.Expect(x).Should(HaveLen(0)) // want `ginkgo-linter: wrong length assertion; consider using .g\.Expect\(x\)\.Should\(BeEmpty\(\)\). instead`
+	g.Expect(x).Should(HaveLen(0))               // want `ginkgo-linter: wrong length assertion; consider using .g\.Expect\(x\)\.Should\(BeEmpty\(\)\). instead`
+	g.Expect(x).WithOffset(1).Should(HaveLen(0)) // want `ginkgo-linter: wrong length assertion; consider using .g\.Expect\(x\)\.WithOffset\(1\)\.Should\(BeEmpty\(\)\). instead`
 
 	x = append(x, 1)
 	g.Expect(x).Should(Not(HaveLen(0))) // want `ginkgo-linter: wrong length assertion; consider using .g\.Expect\(x\)\.ShouldNot\(BeEmpty\(\)\). instead`

--- a/testdata/src/a/havelen0/havelen0.go
+++ b/testdata/src/a/havelen0/havelen0.go
@@ -10,8 +10,9 @@ const EMPTY = 0
 var _ = Describe("test HaveLen(0)", func() {
 	It("should replace HaveLen(0) with BeEmpty()", func() {
 		x := make([]int, 0)
-		Expect(x).To(HaveLen(0))     // want `ginkgo-linter: wrong length assertion; consider using .Expect\(x\)\.To\(BeEmpty\(\)\). instead`
-		Expect(x).To(HaveLen(EMPTY)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(x\)\.To\(BeEmpty\(\)\). instead`
+		Expect(x).To(HaveLen(0))               // want `ginkgo-linter: wrong length assertion; consider using .Expect\(x\)\.To\(BeEmpty\(\)\). instead`
+		Expect(x).WithOffset(1).To(HaveLen(0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(x\)\.WithOffset\(1\)\.To\(BeEmpty\(\)\). instead`
+		Expect(x).To(HaveLen(EMPTY))           // want `ginkgo-linter: wrong length assertion; consider using .Expect\(x\)\.To\(BeEmpty\(\)\). instead`
 
 		x = append(x, 1)
 		Expect(x).To(Not(HaveLen(0)))     // want `ginkgo-linter: wrong length assertion; consider using .Expect\(x\)\.ToNot\(BeEmpty\(\)\). instead`

--- a/testdata/src/a/len/a.go
+++ b/testdata/src/a/len/a.go
@@ -9,7 +9,8 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 	Context("test Expect", func() {
 		Context("test Should", func() {
 			It("should suggest HaveLen", func() {
-				Expect(len("abcd")).Should(Equal(4)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.Should\(HaveLen\(4\)\). instead`
+				Expect(len("abcd")).Should(Equal(4))               // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.Should\(HaveLen\(4\)\). instead`
+				Expect(len("abcd")).WithOffset(1).Should(Equal(4)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.WithOffset\(1\)\.Should\(HaveLen\(4\)\). instead`
 			})
 
 			It("should suggest BeEmpty", func() {

--- a/testdata/src/a/nil/a.go
+++ b/testdata/src/a/nil/a.go
@@ -24,8 +24,9 @@ var _ = Describe("", func() {
 		Context("test Should", func() {
 			Context("test BeTrue", func() {
 				It("test nil value", func() {
-					Expect(x == nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
-					Expect(nil == x).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(x == nil).Should(BeTrue())               // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
+					Expect(x == nil).WithOffset(1).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.WithOffset\(1\)\.Should\(BeNil\(\)\). instead`
+					Expect(nil == x).Should(BeTrue())               // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(x\)\.Should\(BeNil\(\)\). instead`
 				})
 				It("test non-nil value", func() {
 					Expect(y != nil).Should(BeTrue()) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(y\)\.ShouldNot\(BeNil\(\)\). instead`

--- a/testdata/src/a/nodotimport/a.go
+++ b/testdata/src/a/nodotimport/a.go
@@ -8,13 +8,14 @@ import (
 var _ = ginkgo.Describe("no dot import", func() {
 	ginkgo.It("should trigger length warning", func() {
 		const length = 3
-		gomega.Expect(len("abc")).Should(gomega.Equal(3))               // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.Should\(gomega\.HaveLen\(3\)\). instead`
-		gomega.Expect(len("abc")).Should(gomega.Not(gomega.Equal(4)))   // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.ShouldNot\(gomega\.HaveLen\(4\)\). instead`
-		gomega.Expect(len("abc")).Should(gomega.Equal(length))          // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.Should\(gomega\.HaveLen\(length\)\). instead`
-		gomega.Expect(len("")).Should(gomega.Equal(0))                  // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\(""\)\.Should\(gomega\.BeEmpty\(\)\). instead`
-		gomega.Expect(len("abc")).ShouldNot(gomega.BeZero())            // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.ShouldNot\(gomega\.BeEmpty\(\)\). instead`
-		gomega.Expect(len("abc")).Should(gomega.BeNumerically(">", 0))  // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.ShouldNot\(gomega\.BeEmpty\(\)\). instead`
-		gomega.Expect(len("abc")).Should(gomega.BeNumerically("==", 3)) // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.Should\(gomega\.HaveLen\(3\)\). instead`
+		gomega.Expect(len("abc")).Should(gomega.Equal(3))                             // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.Should\(gomega\.HaveLen\(3\)\). instead`
+		gomega.Expect(len("abc")).Should(gomega.Not(gomega.Equal(4)))                 // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.ShouldNot\(gomega\.HaveLen\(4\)\). instead`
+		gomega.Expect(len("abc")).Should(gomega.Equal(length))                        // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.Should\(gomega\.HaveLen\(length\)\). instead`
+		gomega.Expect(len("")).Should(gomega.Equal(0))                                // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\(""\)\.Should\(gomega\.BeEmpty\(\)\). instead`
+		gomega.Expect(len("abc")).ShouldNot(gomega.BeZero())                          // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.ShouldNot\(gomega\.BeEmpty\(\)\). instead`
+		gomega.Expect(len("abc")).Should(gomega.BeNumerically(">", 0))                // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.ShouldNot\(gomega\.BeEmpty\(\)\). instead`
+		gomega.Expect(len("abc")).Should(gomega.BeNumerically("==", 3))               // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.Should\(gomega\.HaveLen\(3\)\). instead`
+		gomega.Expect(len("abc")).WithOffset(1).Should(gomega.BeNumerically("==", 3)) // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("abc"\)\.WithOffset\(1\)\.Should\(gomega\.HaveLen\(3\)\). instead`
 	})
 	ginkgo.It("should trigger nil warning", func() {
 		var x *int

--- a/testdata/src/a/nodotimport/b.go
+++ b/testdata/src/a/nodotimport/b.go
@@ -8,12 +8,13 @@ import (
 var _ = g1.Describe("no dot import", func() {
 	g1.It("should ignore length warning", func() {
 		const length = 3
-		g2.Expect(len("abc")).Should(g2.Equal(3))               // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\("abc"\)\.Should\(g2\.HaveLen\(3\)\). instead`
-		g2.Expect(len("abc")).Should(g2.Equal(length))          // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\("abc"\)\.Should\(g2\.HaveLen\(length\)\). instead`
-		g2.Expect(len("")).Should(g2.Equal(0))                  // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\(""\)\.Should\(g2\.BeEmpty\(\)\). instead`
-		g2.Expect(len("abc")).ShouldNot(g2.BeZero())            // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\("abc"\)\.ShouldNot\(g2\.BeEmpty\(\)\). instead`
-		g2.Expect(len("abc")).Should(g2.BeNumerically(">", 0))  // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\("abc"\)\.ShouldNot\(g2\.BeEmpty\(\)\). instead`
-		g2.Expect(len("abc")).Should(g2.BeNumerically("==", 3)) // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\("abc"\).Should\(g2\.HaveLen\(3\)\). instead`
+		g2.Expect(len("abc")).Should(g2.Equal(3))                             // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\("abc"\)\.Should\(g2\.HaveLen\(3\)\). instead`
+		g2.Expect(len("abc")).Should(g2.Equal(length))                        // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\("abc"\)\.Should\(g2\.HaveLen\(length\)\). instead`
+		g2.Expect(len("")).Should(g2.Equal(0))                                // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\(""\)\.Should\(g2\.BeEmpty\(\)\). instead`
+		g2.Expect(len("abc")).ShouldNot(g2.BeZero())                          // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\("abc"\)\.ShouldNot\(g2\.BeEmpty\(\)\). instead`
+		g2.Expect(len("abc")).Should(g2.BeNumerically(">", 0))                // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\("abc"\)\.ShouldNot\(g2\.BeEmpty\(\)\). instead`
+		g2.Expect(len("abc")).Should(g2.BeNumerically("==", 3))               // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\("abc"\)\.Should\(g2\.HaveLen\(3\)\). instead`
+		g2.Expect(len("abc")).WithOffset(1).Should(g2.BeNumerically("==", 3)) // want `ginkgo-linter: wrong length assertion; consider using .g2\.Expect\("abc"\)\.WithOffset\(1\)\.Should\(g2\.HaveLen\(3\)\). instead`
 	})
 	g1.It("should trigger nil warning", func() {
 		var x *int

--- a/testdata/src/a/pointers/pointers.go
+++ b/testdata/src/a/pointers/pointers.go
@@ -28,8 +28,9 @@ var _ = Describe("", func() {
 	It("", func() {
 		val1, val2 := 8, 8
 		p1, p2, p3 := &val1, &val1, &val2
-		Expect(p1 == p2).To(BeTrue())  // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(p1\)\.To\(BeIdenticalTo\(p2\)\). instead`
-		Expect(p1 == p3).To(BeFalse()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(p1\)\.ToNot\(BeIdenticalTo\(p3\)\). instead`
+		Expect(p1 == p2).To(BeTrue())                // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(p1\)\.To\(BeIdenticalTo\(p2\)\). instead`
+		Expect(p1 == p3).To(BeFalse())               // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(p1\)\.ToNot\(BeIdenticalTo\(p3\)\). instead`
+		Expect(p1 == p3).WithOffset(1).To(BeFalse()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(p1\)\.WithOffset\(1\)\.ToNot\(BeIdenticalTo\(p3\)\). instead`
 	})
 
 	It("", func() {
@@ -46,6 +47,7 @@ var _ = Describe("", func() {
 		Expect(t1.in.i != t3.in.i).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(t1.in.i\)\.ToNot\(BeIdenticalTo\(t3.in.i\)\). instead`
 
 		t4 := GetBBB()
-		Expect(t4 == t1).To(BeFalse()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(t4\)\.ToNot\(BeIdenticalTo\(t1\)\). instead`
+		Expect(t4 == t1).To(BeFalse())               // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(t4\)\.ToNot\(BeIdenticalTo\(t1\)\). instead`
+		Expect(t4 == t1).WithOffset(1).To(BeFalse()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(t4\)\.WithOffset\(1\)\.ToNot\(BeIdenticalTo\(t1\)\). instead`
 	})
 })

--- a/testdata/src/a/suppress/e.go
+++ b/testdata/src/a/suppress/e.go
@@ -3,6 +3,7 @@ package suppress
 // ginkgo-linter:ignore-len-assert-warning
 // ginkgo-linter:ignore-nil-assert-warning
 // ginkgo-linter:ignore-err-assert-warning
+// ginkgo-linter:ignore-compare-assert-warning
 // Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
 // aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 // Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint

--- a/testdata/src/a/suppress/f.go
+++ b/testdata/src/a/suppress/f.go
@@ -11,6 +11,7 @@ var _ = Describe("suppress file", func() {
 		// ginkgo-linter:ignore-nil-assert-warning
 		// ginkgo-linter:ignore-len-assert-warning
 		// ginkgo-linter:ignore-err-assert-warning
+		// ginkgo-linter:ignore-compare-assert-warning
 		// check that linter is suppressed when all flags are true
 		Expect(len(x)).Should(Equal(4))
 	})


### PR DESCRIPTION
The linter used to ignore patterns like
`Expect(len(x)).WithOffset(1).Should(Equal3))`. now the linter will catch these patterns as well.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added test case and related test data
- [x] Update the functional test

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)
