### PR TITLE
Avoid double negative assertions

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -41,10 +41,10 @@ jobs:
         cp ginkgolinter testdata/src/a
         cd testdata/src/a
 
-        [[ $(./ginkgolinter ./... 2>&1 | wc -l) == 2217 ]]
-        [[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 1378 ]]
-        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 638 ]]
-        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 131 ]]
-        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true ./... 2>&1 | wc -l) == 118 ]]
-        [[ $(./ginkgolinter --allow-havelen-0=true ./... 2>&1 | wc -l) == 2205 ]]
+        [[ $(./ginkgolinter ./... 2>&1 | wc -l) == 2223 ]]
+        [[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 1384 ]]
+        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 644 ]]
+        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 137 ]]
+        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true ./... 2>&1 | wc -l) == 124 ]]
+        [[ $(./ginkgolinter --allow-havelen-0=true ./... 2>&1 | wc -l) == 2211 ]]
         [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 0 ]]

--- a/reverseassertion/reverse_assertion.go
+++ b/reverseassertion/reverse_assertion.go
@@ -18,6 +18,14 @@ func ChangeAssertionLogic(funcName string) string {
 	return funcName
 }
 
+func IsNegativeLogic(funcName string) bool {
+	switch funcName {
+	case "ToNot", "NotTo", "ShouldNot":
+		return true
+	}
+	return false
+}
+
 var reverseCompareOperators = map[token.Token]token.Token{
 	token.LSS: token.GTR,
 	token.GTR: token.LSS,

--- a/reverseassertion/reverse_assertion_test.go
+++ b/reverseassertion/reverse_assertion_test.go
@@ -64,3 +64,21 @@ func TestChangeCompareOperator(t *testing.T) {
 		})
 	}
 }
+
+func TestIsNegativeLogic(t *testing.T) {
+	for _, funcName := range []string{"ToNot", "NotTo", "ShouldNot"} {
+		t.Run("check "+funcName, func(tt *testing.T) {
+			if !reverseassertion.IsNegativeLogic(funcName) {
+				tt.Errorf("%s should be a negative function", funcName)
+			}
+		})
+	}
+
+	for _, methodName := range []string{"To", "Should", "Unsupported"} {
+		t.Run("check "+methodName, func(tt *testing.T) {
+			if reverseassertion.IsNegativeLogic(methodName) {
+				tt.Errorf("%s should be a positive method", methodName)
+			}
+		})
+	}
+}

--- a/testdata/src/a/boolean/bool.go
+++ b/testdata/src/a/boolean/bool.go
@@ -5,13 +5,23 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Equal(true/false)", func() {
+var _ = Describe("boolean warnings", func() {
+	t := true
+	f := false
+
 	It("check Equal(true/false)", func() {
-		t := true
-		f := false
 		Expect(t).To(Equal(true))                        // want `ginkgo-linter: wrong boolean assertion; consider using .Expect\(t\)\.To\(BeTrue\(\)\). instead`
 		Expect(f).To(Equal(false))                       // want `ginkgo-linter: wrong boolean assertion; consider using .Expect\(f\)\.To\(BeFalse\(\)\). instead`
-		ExpectWithOffset(2, t).Should(Not(Equal(false))) // want `ginkgo-linter: wrong boolean assertion; consider using .ExpectWithOffset\(2, t\)\.ShouldNot\(BeFalse\(\)\). instead`
+		ExpectWithOffset(2, t).Should(Not(Equal(false))) // want `ginkgo-linter: wrong boolean assertion; consider using .ExpectWithOffset\(2, t\)\.Should\(BeTrue\(\)\). instead`
+		ExpectWithOffset(2, t).ShouldNot(Equal(false))   // want `ginkgo-linter: wrong boolean assertion; consider using .ExpectWithOffset\(2, t\)\.Should\(BeTrue\(\)\). instead`
+		Expect(t).WithOffset(2).ToNot(Equal(false))      // want `ginkgo-linter: wrong boolean assertion; consider using .Expect\(t\)\.WithOffset\(2\)\.To\(BeTrue\(\)\). instead`
+		Expect(t).NotTo(Equal(false))                    // want `ginkgo-linter: wrong boolean assertion; consider using .Expect\(t\)\.To\(BeTrue\(\)\). instead`
 		Expect(f).WithOffset(1).ToNot(Equal(true))       // want `ginkgo-linter: wrong boolean assertion; consider using .Expect\(f\)\.WithOffset\(1\)\.ToNot\(BeTrue\(\)\). instead`
+	})
+
+	It("check double negative", func() {
+		Expect(t).ToNot(BeFalse())                   // want `ginkgo-linter: avoid double negative assertion; consider using .Expect\(t\)\.To\(BeTrue\(\)\). instead`
+		Expect(t).NotTo(BeFalse())                   // want `ginkgo-linter: avoid double negative assertion; consider using .Expect\(t\)\.To\(BeTrue\(\)\). instead`
+		Expect(t).WithOffset(2).ShouldNot(BeFalse()) // want `ginkgo-linter: avoid double negative assertion; consider using .Expect\(t\)\.WithOffset\(2\)\.Should\(BeTrue\(\)\). instead`
 	})
 })


### PR DESCRIPTION
# Description
Patterns like `Expect(boolVal).ShouldNot(Equal(false))` or `Expect(boolVal).ShouldNot(BeFalse())`, the linter will suggest `Expect(boolVal).Should(BeTrue())`
## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [x] Added test case and related test data
- [x] Update the functional test

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)
