### PR TITLE
Fix bug in comparison rule

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -41,10 +41,10 @@ jobs:
         cp ginkgolinter testdata/src/a
         cd testdata/src/a
 
-        [[ $(./ginkgolinter ./... 2>&1 | wc -l) == 2223 ]]
+        [[ $(./ginkgolinter ./... 2>&1 | wc -l) == 2236 ]]
         [[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 1384 ]]
-        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 644 ]]
+        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 649 ]]
         [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 137 ]]
-        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true ./... 2>&1 | wc -l) == 124 ]]
-        [[ $(./ginkgolinter --allow-havelen-0=true ./... 2>&1 | wc -l) == 2211 ]]
+        [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true ./... 2>&1 | wc -l) == 137 ]]
+        [[ $(./ginkgolinter --allow-havelen-0=true ./... 2>&1 | wc -l) == 2224 ]]
         [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true ./... 2>&1 | wc -l) == 0 ]]

--- a/testdata/src/a/comparison/comparison.go
+++ b/testdata/src/a/comparison/comparison.go
@@ -110,9 +110,30 @@ var _ = Describe("remove comparison", func() {
 			Expect(constTwo >= exampleInt).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\("<=", constTwo\)\). instead`
 			Expect(exampleInt <= constTwo).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\("<=", constTwo\)\). instead`
 			Expect(exampleInt).To(BeNumerically("<=", 2))
-			Expect(exampleInt <= 2).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\("<=", 2\)\). instead`
-			Expect(2 >= exampleInt).To(BeTrue()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\("<=", 2\)\). instead`
+			Expect(exampleInt <= 2).To(BeTrue())     // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\("<=", 2\)\). instead`
+			Expect(2 >= exampleInt).To(BeTrue())     // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\("<=", 2\)\). instead`
+			Expect(2 >= exampleInt).ToNot(BeFalse()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(exampleInt\)\.To\(BeNumerically\("<=", 2\)\). instead`
 		})
 
+	})
+
+	Context("length comparison", func() {
+		It("should not allow len() comparison", func() {
+			s := []int{1, 2, 3, 4}
+			Expect(len(s) == 4).Should(BeTrue()) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(s\)\.Should\(HaveLen\(4\)\). instead`
+			Expect(s).Should(HaveLen(4))
+
+			Expect(len(s) == 4).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(s\)\.Should\(HaveLen\(4\)\). instead`
+			Expect(len(s) != 5).Should(BeTrue())     // want `ginkgo-linter: wrong length assertion; consider using .Expect\(s\)\.ShouldNot\(HaveLen\(5\)\). instead`
+			Expect(len(s) != 5).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(s\)\.ShouldNot\(HaveLen\(5\)\). instead`
+			Expect(len(s) != 0).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong length assertion; consider using .Expect\(s\)\.ShouldNot\(BeEmpty\(\)\). instead`
+			Expect(len(s) < 5).Should(BeTrue())      // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(len\(s\)\)\.Should\(BeNumerically\("<", 5\)\). instead`
+			Expect(len(s) < 5).Should(Equal(true))   // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(len\(s\)\)\.Should\(BeNumerically\("<", 5\)\). instead`
+			Expect(len(s) < 5).ShouldNot(BeFalse())  // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(len\(s\)\)\.Should\(BeNumerically\("<", 5\)\). instead`
+			Expect(len(s) <= 5).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(len\(s\)\)\.Should\(BeNumerically\("<=", 5\)\). instead`
+			Expect(len(s) > 3).ShouldNot(BeFalse())  // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(len\(s\)\)\.Should\(BeNumerically\(">", 3\)\). instead`
+			Expect(len(s) >= 3).ShouldNot(BeFalse()) // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(len\(s\)\)\.Should\(BeNumerically\(">=", 3\)\). instead`
+			Expect(len(s) < 3).Should(BeFalse())     // want `ginkgo-linter: wrong comparison assertion; consider using .Expect\(len\(s\)\)\.ShouldNot\(BeNumerically\("<", 3\)\). instead`
+		})
 	})
 })


### PR DESCRIPTION
# Description
When comparing len() result with a number, the linter used to wrongly fix `Expect(len(x) == 5).To(BeTrue())` to `Expect(len(x)).To(Equal(5))`, which is also a wrong pattern.

This PR fixes this bug and fix the wrong patter to `Expect(x).To(HaveLen(5))`

Note: this is only for equal or not-equal comparison.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Added test case and related test data
- [x] Update the functional test

# Checklist:

- [x] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)

