### PR TITLE
Add new linter rule: Compare pointer to value

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,29 @@ It("should test that slowInt returns 42, eventually", func() {
 })
 ```
 
+### Comparing a pointer with a value
+The linter warns when comparing a pointer with a value.
+These comparisons are always wrong and will always fail.
+
+In case of a positive assertion (`To()` or `Should()`), the test will just fail.
+
+But the main concern is for false positive tests, when using a negative assertion (`NotTo()`, `ToNot()`, `ShouldNot()`,
+`Should(Not())` etc.); e.g.
+```go
+num := 5
+...
+pNum := &num
+...
+Expect(pNum).ShouldNot(Equal(6))
+```
+This assertion will pass, but for the wrong reasons: pNum is not equal 6, not because num == 5, but because pNum is
+a pointer, while `6` is an `int`.
+
+In the case above, the linter will suggest `Expect(pNum).ShouldNot(HaveValue(Equal(6)))`
+
+This is also right for additional matchers: `BeTrue()` and `BeFalse()`, `BeIdenticalTo()`, `BeEquivalentTo()` 
+and `BeNumerically`.
+
 ## Suppress the linter
 ### Suppress warning from command line
 * Use the `--suppress-len-assertion=true` flag to suppress the wrong length assertion warning

--- a/ginkgo_linter.go
+++ b/ginkgo_linter.go
@@ -31,21 +31,26 @@ const (
 	wrongCompareWarningTemplate   = linterName + ": wrong comparison assertion; consider using `%s` instead"
 	doubleNegativeWarningTemplate = linterName + ": avoid double negative assertion; consider using `%s` instead"
 	valueInEventually             = linterName + ": use a function call in %s. This actually checks nothing, because %s receives the function returned value, instead of function itself, and this value is never changed"
-	beEmpty                       = "BeEmpty"
-	beNil                         = "BeNil"
-	beTrue                        = "BeTrue"
-	beFalse                       = "BeFalse"
-	beZero                        = "BeZero"
-	beNumerically                 = "BeNumerically"
-	beIdenticalTo                 = "BeIdenticalTo"
-	equal                         = "Equal"
-	not                           = "Not"
-	haveLen                       = "HaveLen"
-	succeed                       = "Succeed"
-	haveOccurred                  = "HaveOccurred"
-	expect                        = "Expect"
-	omega                         = "Ω"
-	expectWithOffset              = "ExpectWithOffset"
+	comparePointerToValue         = linterName + ": comparing a pointer to a value will always fail. consider using `%s` instead"
+)
+const ( // gomega methods
+	beEmpty          = "BeEmpty"
+	beEquivalentTo   = "BeEquivalentTo"
+	beFalse          = "BeFalse"
+	beIdenticalTo    = "BeIdenticalTo"
+	beNil            = "BeNil"
+	beNumerically    = "BeNumerically"
+	beTrue           = "BeTrue"
+	beZero           = "BeZero"
+	equal            = "Equal"
+	expect           = "Expect"
+	expectWithOffset = "ExpectWithOffset"
+	haveLen          = "HaveLen"
+	haveOccurred     = "HaveOccurred"
+	haveValue        = "HaveValue"
+	not              = "Not"
+	omega            = "Ω"
+	succeed          = "Succeed"
 )
 
 // Analyzer is the interface to go_vet
@@ -68,10 +73,10 @@ func NewAnalyzer() *analysis.Analyzer {
 	}
 
 	a := &analysis.Analyzer{
-		Name:             "ginkgolinter",
-		Doc:              doc,
-		Run:              linter.run,
-		RunDespiteErrors: true,
+		Name: "ginkgolinter",
+		Doc:  doc,
+		Run:  linter.run,
+		//RunDespiteErrors: true,
 	}
 
 	a.Flags.Init("ginkgolinter", flag.ExitOnError)
@@ -117,6 +122,8 @@ This should be replaced with:
 * trigger a warning when using Eventually or Constantly with a function call. This is in order to prevent the case when 
   using a function call instead of a function. Function call returns a value only once, and so the original value
   is tested again and again and is never changed.
+
+* trigger a warning when comparing a pointer to a value.
 `
 
 // main assertion function
@@ -175,10 +182,10 @@ func (l *ginkgoLinter) run(pass *analysis.Pass) (interface{}, error) {
 }
 
 func checkExpression(pass *analysis.Pass, config types.Config, assertionExp *ast.CallExpr, actualExpr *ast.CallExpr, handler gomegahandler.Handler) bool {
-	assertionExp = astcopy.CallExpr(assertionExp)
-	oldExpr := goFmt(pass.Fset, assertionExp)
+	expr := astcopy.CallExpr(assertionExp)
+	oldExpr := goFmt(pass.Fset, expr)
 
-	if checkAsyncAssertion(pass, config, assertionExp, actualExpr, handler, oldExpr) {
+	if checkAsyncAssertion(pass, config, expr, actualExpr, handler, oldExpr) {
 		return true
 	}
 
@@ -188,38 +195,94 @@ func checkExpression(pass *analysis.Pass, config types.Config, assertionExp *ast
 	}
 
 	if !bool(config.SuppressLen) && isActualIsLenFunc(actualArg) {
-		return checkLengthMatcher(assertionExp, pass, handler, oldExpr)
-	} else {
-		if nilable, compOp := getNilableFromComparison(actualArg); nilable != nil {
-			if isExprError(pass, nilable) {
-				if config.SuppressErr {
-					return true
-				}
-			} else if config.SuppressNil {
+		return checkLengthMatcher(expr, pass, handler, oldExpr)
+	} else if nilable, compOp := getNilableFromComparison(actualArg); nilable != nil {
+		if isExprError(pass, nilable) {
+			if config.SuppressErr {
 				return true
 			}
+		} else if config.SuppressNil {
+			return true
+		}
 
-			return checkNilMatcher(assertionExp, pass, nilable, handler, compOp == token.NEQ, oldExpr)
+		return checkNilMatcher(expr, pass, nilable, handler, compOp == token.NEQ, oldExpr)
 
-		} else if first, second, op, ok := isComparison(pass, actualArg); ok {
-			matcher, shouldContinue := startCheckComparison(assertionExp, handler)
-			if !shouldContinue {
+	} else if first, second, op, ok := isComparison(pass, actualArg); ok {
+		matcher, shouldContinue := startCheckComparison(expr, handler)
+		if !shouldContinue {
+			return false
+		}
+		if !bool(config.SuppressLen) && isActualIsLenFunc(first) {
+			if handleLenComparison(pass, expr, matcher, first, second, op, handler, oldExpr) {
 				return false
 			}
-			if !bool(config.SuppressLen) && isActualIsLenFunc(first) {
-				if handleLenComparison(pass, assertionExp, matcher, first, second, op, handler, oldExpr) {
-					return false
-				}
-			}
-			return bool(config.SuppressCompare) || checkComparison(assertionExp, pass, matcher, handler, first, second, op, oldExpr)
+		}
+		return bool(config.SuppressCompare) || checkComparison(expr, pass, matcher, handler, first, second, op, oldExpr)
 
-		} else if isExprError(pass, actualArg) {
-			return bool(config.SuppressErr) || checkNilError(pass, assertionExp, handler, actualArg, oldExpr)
+	} else if isExprError(pass, actualArg) {
+		return bool(config.SuppressErr) || checkNilError(pass, expr, handler, actualArg, oldExpr)
 
-		} else {
-			return handleAssertionOnly(pass, config, assertionExp, handler, actualArg, oldExpr, true)
+	} else if checkPointerComparison(pass, config, assertionExp, expr, actualArg, handler, oldExpr) {
+		return false
+	} else {
+		return handleAssertionOnly(pass, config, expr, handler, actualArg, oldExpr, true)
+	}
+}
+
+// be careful - never change origExp!!! only modify its clone, expr!!!
+func checkPointerComparison(pass *analysis.Pass, config types.Config, origExp *ast.CallExpr, expr *ast.CallExpr, actualArg ast.Expr, handler gomegahandler.Handler, oldExpr string) bool {
+	if !isPointer(pass, actualArg) {
+		return false
+	}
+	matcher, ok := origExp.Args[0].(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+
+	matcherFuncName, ok := handler.GetActualFuncName(matcher)
+	if !ok {
+		return false
+	}
+
+	// not using recurse here, since we need the original expression, in order to get the TypeInfo, while we should not
+	// modify it.
+	for matcherFuncName == not {
+		reverseAssertionFuncLogic(expr)
+		expr.Args[0] = expr.Args[0].(*ast.CallExpr).Args[0]
+		matcher, ok = matcher.Args[0].(*ast.CallExpr)
+		if !ok {
+			return false
+		}
+
+		matcherFuncName, ok = handler.GetActualFuncName(matcher)
+		if !ok {
+			return false
 		}
 	}
+
+	switch matcherFuncName {
+	case equal, beIdenticalTo, beEquivalentTo:
+		arg := matcher.Args[0]
+		if isPointer(pass, arg) {
+			return false
+		}
+		if isNil(arg) {
+			return false
+		}
+	case beFalse, beTrue, beNumerically:
+	default:
+		return false
+	}
+
+	handleAssertionOnly(pass, config, expr, handler, actualArg, oldExpr, false)
+
+	args := []ast.Expr{astcopy.CallExpr(expr.Args[0].(*ast.CallExpr))}
+	handler.ReplaceFunction(expr.Args[0].(*ast.CallExpr), ast.NewIdent(haveValue))
+	expr.Args[0].(*ast.CallExpr).Args = args
+	report(pass, expr, comparePointerToValue, oldExpr)
+
+	return true
+
 }
 
 // check async assertion does not assert function call. This is a real bug in the test. In this case, the assertion is
@@ -547,12 +610,12 @@ func checkNilError(pass *analysis.Pass, assertionExp *ast.CallExpr, handler gome
 //	Equal(true) => BeTrue()
 //	Equal(false) => BeFalse()
 //	HaveLen(0) => BeEmpty()
-func handleAssertionOnly(pass *analysis.Pass, config types.Config, assertionExp *ast.CallExpr, handler gomegahandler.Handler, actualArg ast.Expr, oldExpr string, shouldReport bool) bool {
-	if len(assertionExp.Args) == 0 {
+func handleAssertionOnly(pass *analysis.Pass, config types.Config, expr *ast.CallExpr, handler gomegahandler.Handler, actualArg ast.Expr, oldExpr string, shouldReport bool) bool {
+	if len(expr.Args) == 0 {
 		return true
 	}
 
-	equalFuncExpr, ok := assertionExp.Args[0].(*ast.CallExpr)
+	equalFuncExpr, ok := expr.Args[0].(*ast.CallExpr)
 	if !ok {
 		return true
 	}
@@ -586,8 +649,8 @@ func handleAssertionOnly(pass *analysis.Pass, config types.Config, assertionExp 
 			replacement = beTrue
 			template = wrongBoolWarningTemplate
 		case "false":
-			if isNegativeAssertion(assertionExp) {
-				reverseAssertionFuncLogic(assertionExp)
+			if isNegativeAssertion(expr) {
+				reverseAssertionFuncLogic(expr)
 				replacement = beTrue
 			} else {
 				replacement = beFalse
@@ -601,17 +664,17 @@ func handleAssertionOnly(pass *analysis.Pass, config types.Config, assertionExp 
 		equalFuncExpr.Args = nil
 
 		if shouldReport {
-			report(pass, assertionExp, template, oldExpr)
+			report(pass, expr, template, oldExpr)
 		}
 
 		return false
 
 	case beFalse:
-		if isNegativeAssertion(assertionExp) {
-			reverseAssertionFuncLogic(assertionExp)
+		if isNegativeAssertion(expr) {
+			reverseAssertionFuncLogic(expr)
 			handler.ReplaceFunction(equalFuncExpr, ast.NewIdent(beTrue))
 			if shouldReport {
-				report(pass, assertionExp, doubleNegativeWarningTemplate, oldExpr)
+				report(pass, expr, doubleNegativeWarningTemplate, oldExpr)
 			}
 		}
 		return false
@@ -626,7 +689,7 @@ func handleAssertionOnly(pass *analysis.Pass, config types.Config, assertionExp 
 				handler.ReplaceFunction(equalFuncExpr, ast.NewIdent(beEmpty))
 				equalFuncExpr.Args = nil
 				if shouldReport {
-					report(pass, assertionExp, wrongLengthWarningTemplate, oldExpr)
+					report(pass, expr, wrongLengthWarningTemplate, oldExpr)
 				}
 				return false
 			}
@@ -635,9 +698,9 @@ func handleAssertionOnly(pass *analysis.Pass, config types.Config, assertionExp 
 		return true
 
 	case not:
-		reverseAssertionFuncLogic(assertionExp)
-		assertionExp.Args[0] = assertionExp.Args[0].(*ast.CallExpr).Args[0]
-		return handleAssertionOnly(pass, config, assertionExp, handler, actualArg, oldExpr, shouldReport)
+		reverseAssertionFuncLogic(expr)
+		expr.Args[0] = expr.Args[0].(*ast.CallExpr).Args[0]
+		return handleAssertionOnly(pass, config, expr, handler, actualArg, oldExpr, shouldReport)
 	default:
 		return true
 	}
@@ -988,4 +1051,10 @@ func isExprError(pass *analysis.Pass, expr ast.Expr) bool {
 		}
 	}
 	return false
+}
+
+func isPointer(pass *analysis.Pass, expr ast.Expr) bool {
+	t := pass.TypesInfo.TypeOf(expr)
+	_, ok := t.(*gotypes.Pointer)
+	return ok
 }

--- a/ginkgo_linter_test.go
+++ b/ginkgo_linter_test.go
@@ -65,6 +65,10 @@ func TestAllUseCases(t *testing.T) {
 			testName: "function call in Eventually",
 			testData: "a/eventually",
 		},
+		{
+			testName: "compare pointer to value",
+			testData: "a/pointerval",
+		},
 	} {
 		t.Run(tc.testName, func(tt *testing.T) {
 			analysistest.Run(tt, analysistest.TestData(), ginkgolinter.NewAnalyzer(), tc.testData)

--- a/testdata/src/a/pointerval/pointerval.go
+++ b/testdata/src/a/pointerval/pointerval.go
@@ -1,0 +1,145 @@
+package pointerval
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const c = "a"
+
+type strct struct {
+	field string
+}
+
+type strctPoint struct {
+	field *string
+}
+
+func retStruct() strct {
+	return strct{field: c}
+}
+
+func retStructPointer() *strct {
+	return &strct{field: c}
+}
+
+func retPointer() *string {
+	v := c
+	return &v
+}
+
+var (
+	v = c
+	p = &v
+)
+var _ = Describe("", Label("pointers1"), func() {
+
+	It("pointer to var", func() {
+		Expect(*p).Should(Equal(v))
+		Expect(p).Should(HaveValue(Equal(v)))
+		Expect(&v).Should(Equal(c)) // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(&v\)\.Should\(HaveValue\(Equal\(c\)\)\). instead`
+		Expect(p).Should(Equal(&v))
+		Expect(p).Should(Equal(v)) // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(p\)\.Should\(HaveValue\(Equal\(v\)\)\). instead`
+	})
+
+	It("with description", func() {
+		Expect(p).Should(Equal(v), "%d", 3) // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(p\)\.Should\(HaveValue\(Equal\(v\)\), "%d", 3\). instead`
+	})
+
+	It("pointer to const", func() {
+		Expect(*p).Should(Equal(c))
+		Expect(p).Should(HaveValue(Equal(c)))
+		Expect(p).Should(Equal(c)) // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(p\)\.Should\(HaveValue\(Equal\(c\)\)\). instead`
+	})
+
+	It("function", func() {
+		Expect(retPointer()).Should(HaveValue(Equal(c))) // valid
+		Expect(*retPointer()).Should(Equal(c))           // valid
+		Expect(retPointer()).Should(Equal(c))            // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(retPointer\(\)\)\.Should\(HaveValue\(Equal\(c\)\)\). instead`
+	})
+
+	Context("struct", func() {
+		s1 := strct{field: c}
+		s2 := &strct{field: c}
+		s3 := strctPoint{field: &v}
+		s4 := &strctPoint{field: &v}
+
+		It("struct with non-pointer field", func() {
+			Expect(s1.field).Should(Equal(c)) // valid
+		})
+		It("struct pointer with non-pointer field", func() {
+			Expect(s2.field).Should(Equal(c)) // valid
+		})
+		It("struct with pointer field", func() {
+			Expect(*s3.field).Should(Equal(c))           // valid
+			Expect(s3.field).Should(HaveValue(Equal(c))) // valid
+			Expect(s3.field).Should(Equal(c))            // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(s3\.field\)\.Should\(HaveValue\(Equal\(c\)\)\). instead`
+		})
+		It("pointer struct with pointer field", func() {
+			Expect(*s4.field).Should(Equal(c))           // valid
+			Expect(s4.field).Should(HaveValue(Equal(c))) // valid
+			Expect(s4.field).Should(Equal(c))            // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(s4\.field\)\.Should\(HaveValue\(Equal\(c\)\)\). instead`
+		})
+	})
+
+	Context("negative", func() {
+		var n *string
+		Expect(n).ShouldNot(Equal(c)) // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(n\)\.ShouldNot\(HaveValue\(Equal\(c\)\)\). instead`
+		Expect(n).To(Not(Equal(c)))   // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(n\)\.ToNot\(HaveValue\(Equal\(c\)\)\). instead`
+	})
+
+	It("do not add HaveValue for nil", func() {
+		Expect(p).ShouldNot(Equal(nil)) // want `ginkgo-linter: wrong nil assertion; consider using .Expect\(p\)\.ShouldNot\(BeNil\(\)\). instead`
+		Expect(p).ShouldNot(BeNil())    // valid
+	})
+	Context("boolean", func() {
+		t := true
+		f := false
+		pt := &t
+		pf := &f
+
+		It("true", func() {
+			Expect(pt).Should(Equal(true))     // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(pt\)\.Should\(HaveValue\(BeTrue\(\)\)\). instead`
+			Expect(pt).ShouldNot(Equal(false)) // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(pt\)\.Should\(HaveValue\(BeTrue\(\)\)\). instead`
+		})
+
+		It("BeTrue", func() {
+			Expect(pt).Should(BeTrue())     // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(pt\)\.Should\(HaveValue\(BeTrue\(\)\)\). instead`
+			Expect(pt).ShouldNot(BeFalse()) // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(pt\)\.Should\(HaveValue\(BeTrue\(\)\)\). instead`
+		})
+
+		It("false", func() {
+			Expect(pf).Should(Equal(false))   // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(pf\)\.Should\(HaveValue\(BeFalse\(\)\)\). instead`
+			Expect(pf).ShouldNot(Equal(true)) // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(pf\)\.ShouldNot\(HaveValue\(BeTrue\(\)\)\). instead`
+		})
+
+		It("Not with boolean", func() {
+			Expect(pf).Should(Not(Equal(true)))  // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(pf\)\.ShouldNot\(HaveValue\(BeTrue\(\)\)\). instead`
+			Expect(pt).Should(Not(Equal(false))) // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(pt\)\.Should\(HaveValue\(BeTrue\(\)\)\). instead`
+		})
+	})
+
+	Context("Other matchers", func() {
+		x := float64(5)
+		y := x
+		px1 := &x
+		px2 := &x
+		It("BeEquivalentTo", func() {
+			Expect(px1).Should(BeEquivalentTo(5))      // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(px1\)\.Should\(HaveValue\(BeEquivalentTo\(5\)\)\). instead`
+			Expect(px1).Should(BeEquivalentTo(y))      // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(px1\)\.Should\(HaveValue\(BeEquivalentTo\(y\)\)\). instead`
+			Expect(px1).Should(BeEquivalentTo(&x))     // valid - compare two pointers
+			Expect(px1).Should(BeEquivalentTo(px2))    // valid - compare two pointers
+			Expect(px1).ShouldNot(BeEquivalentTo(nil)) // valid
+		})
+		It("BeIdenticalTo", func() {
+			Expect(px1).ShouldNot(BeIdenticalTo(5))   // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(px1\)\.ShouldNot\(HaveValue\(BeIdenticalTo\(5\)\)\). instead`
+			Expect(px1).ShouldNot(BeIdenticalTo(px2)) // valid
+			Expect(px1).ShouldNot(BeIdenticalTo(nil))
+			Expect(px1).Should(BeIdenticalTo(float64(5))) // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(px1\)\.Should\(HaveValue\(BeIdenticalTo\(float64\(5\)\)\)\). instead`
+		})
+		It("", func() {
+			Expect(px1).Should(BeNumerically(">", 4))    // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(px1\)\.Should\(HaveValue\(BeNumerically\(">", 4\)\)\). instead`
+			Expect(px1).ShouldNot(BeNumerically(">", 6)) // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(px1\)\.ShouldNot\(HaveValue\(BeNumerically\(">", 6\)\)\). instead`
+		})
+	})
+})

--- a/testdata/src/a/pointerval/pointerval.gomega.go
+++ b/testdata/src/a/pointerval/pointerval.gomega.go
@@ -1,0 +1,78 @@
+package pointerval
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	g "github.com/onsi/gomega"
+)
+
+var _ = Describe("", Label("pointers1"), func() {
+
+	It("pointer to var", func() {
+		g.Expect(*p).Should(g.Equal(v))
+		g.Expect(p).Should(g.HaveValue(g.Equal(v)))
+		g.Expect(p).Should(g.Equal(v)) // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .g\.Expect\(p\)\.Should\(g\.HaveValue\(g\.Equal\(v\)\)\). instead`
+	})
+
+	It("pointer to const", func() {
+		g.Expect(*p).Should(g.Equal(c))
+		g.Expect(p).Should(g.HaveValue(g.Equal(c)))
+		g.Expect(p).Should(g.Equal(c)) // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .g\.Expect\(p\)\.Should\(g\.HaveValue\(g\.Equal\(c\)\)\). instead`
+	})
+
+	It("function", func() {
+		g.Expect(retPointer()).Should(g.HaveValue(g.Equal(c))) // valid
+		g.Expect(*retPointer()).Should(g.Equal(c))             // valid
+		g.Expect(retPointer()).Should(g.Equal(c))              // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .g\.Expect\(retPointer\(\)\)\.Should\(g\.HaveValue\(g\.Equal\(c\)\)\). instead`
+	})
+
+	Context("struct", func() {
+		s1 := strct{field: c}
+		s2 := &strct{field: c}
+		s3 := strctPoint{field: &v}
+		s4 := &strctPoint{field: &v}
+
+		It("struct with non-pointer field", func() {
+			g.Expect(s1.field).Should(g.Equal(c)) // valid
+		})
+		It("struct pointer with non-pointer field", func() {
+			g.Expect(s2.field).Should(g.Equal(c)) // valid
+		})
+		It("struct with pointer field", func() {
+			g.Expect(*s3.field).Should(g.Equal(c))             // valid
+			g.Expect(s3.field).Should(g.HaveValue(g.Equal(c))) // valid
+			g.Expect(s3.field).Should(g.Equal(c))              // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .g\.Expect\(s3\.field\)\.Should\(g\.HaveValue\(g\.Equal\(c\)\)\). instead`
+		})
+		It("pointer struct with pointer field", func() {
+			g.Expect(*s4.field).Should(g.Equal(c))             // valid
+			g.Expect(s4.field).Should(g.HaveValue(g.Equal(c))) // valid
+			g.Expect(s4.field).Should(g.Equal(c))              // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .g\.Expect\(s4\.field\)\.Should\(g\.HaveValue\(g\.Equal\(c\)\)\). instead`
+		})
+	})
+
+	It("do not add HaveValue for nil", func() {
+		g.Expect(p).ShouldNot(g.Equal(nil)) // want `ginkgo-linter: wrong nil assertion; consider using .g\.Expect\(p\)\.ShouldNot\(g\.BeNil\(\)\). instead`
+		g.Expect(p).ShouldNot(g.BeNil())    // valid
+	})
+
+	Context("boolean", func() {
+		t := true
+		f := false
+		pt := &t
+		pf := &f
+
+		It("true", func() {
+			g.Expect(pt).Should(g.Equal(true))     // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .g\.Expect\(pt\)\.Should\(g\.HaveValue\(g\.BeTrue\(\)\)\). instead`
+			g.Expect(pt).ShouldNot(g.Equal(false)) // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .g\.Expect\(pt\)\.Should\(g\.HaveValue\(g\.BeTrue\(\)\)\). instead`
+		})
+
+		It("BeTrue", func() {
+			g.Expect(pt).Should(g.BeTrue())     // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .g\.Expect\(pt\)\.Should\(g\.HaveValue\(g\.BeTrue\(\)\)\). instead`
+			g.Expect(pt).ShouldNot(g.BeFalse()) // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .g\.Expect\(pt\)\.Should\(g\.HaveValue\(g\.BeTrue\(\)\)\). instead`
+		})
+
+		It("false", func() {
+			g.Expect(pf).Should(g.Equal(false))   // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .g\.Expect\(pf\)\.Should\(g\.HaveValue\(g\.BeFalse\(\)\)\). instead`
+			g.Expect(pf).ShouldNot(g.Equal(true)) // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .g\.Expect\(pf\)\.ShouldNot\(g\.HaveValue\(g\.BeTrue\(\)\)\). instead`
+		})
+	})
+})

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -6,18 +6,18 @@ cp ginkgolinter testdata/src/a
 cd testdata/src/a
 
 # no suppress
-[[ $(./ginkgolinter a/... 2>&1 | wc -l) == 2315 ]]
+[[ $(./ginkgolinter a/... 2>&1 | wc -l) == 2351 ]]
 # suppress all but nil
-[[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 1396 ]]
+[[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 1432 ]]
 # suppress all but len
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 686 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 720 ]]
 # suppress all but err
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 157 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 191 ]]
 # suppress all but compare
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 167 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 201 ]]
 # suppress all but async
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true a/... 2>&1 | wc -l) == 64 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true a/... 2>&1 | wc -l) == 98 ]]
 # allow HaveLen(0)
-[[ $(./ginkgolinter --allow-havelen-0=true a/... 2>&1 | wc -l) == 2302 ]]
+[[ $(./ginkgolinter --allow-havelen-0=true a/... 2>&1 | wc -l) == 2338 ]]
 # suppress all - should do nothing
 [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 0 ]]


### PR DESCRIPTION
# Description
The linter warns when comparing a pointer with a value. These comparisons are always wrong and will always fail.

For example:
```go
num := 5
...
pNum := &num
...
Expect(pNum).ShouldNot(Equal(6))
```
The linter will suggest to use this instead:
```go
Expect(pNum).ShouldNot(HaveValue(Equal(6)))
```

Fixes #76 

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
- [x] Added test case and related test data
- [x] Update the functional test

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)

@BorzdeG
