### PR TITLE
bug fix: false negative when comparing a pointer and an interface

### DIFF
--- a/ginkgo_linter.go
+++ b/ginkgo_linter.go
@@ -269,6 +269,9 @@ func checkPointerComparison(pass *analysis.Pass, config types.Config, origExp *a
 		if isNil(arg) {
 			return false
 		}
+		if isInterface(pass, arg) {
+			return false
+		}
 	case beFalse, beTrue, beNumerically:
 	default:
 		return false
@@ -1056,5 +1059,11 @@ func isExprError(pass *analysis.Pass, expr ast.Expr) bool {
 func isPointer(pass *analysis.Pass, expr ast.Expr) bool {
 	t := pass.TypesInfo.TypeOf(expr)
 	_, ok := t.(*gotypes.Pointer)
+	return ok
+}
+
+func isInterface(pass *analysis.Pass, expr ast.Expr) bool {
+	t := pass.TypesInfo.TypeOf(expr)
+	_, ok := t.(*gotypes.Named)
 	return ok
 }


### PR DESCRIPTION
# Description
For example, the function f()'s returned type is an interfce, but it actually returns a pointer.

The linter triggered a warning for this code:
```go
Expect(somePointer).Eqaul(f())
```

But this is a actually a valid assertion.

This PR fixes this bug and does not trigger the warning the assertion compares to `types.Named`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Added test case and related test data
- [x] Update the functional test

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)

@nunnatsa
