### PR TITLE
Fix false positive for string non-equal comparison

### DIFF
--- a/ginkgo_linter.go
+++ b/ginkgo_linter.go
@@ -418,6 +418,9 @@ func checkComparison(exp *ast.CallExpr, pass *analysis.Pass, matcher *ast.CallEx
 		reverseAssertionFuncLogic(exp)
 		handleEqualComparison(pass, matcher, first, second, handler)
 	case token.GTR, token.GEQ, token.LSS, token.LEQ:
+		if !isNumeric(pass, first) {
+			return true
+		}
 		handler.ReplaceFunction(matcher, ast.NewIdent(beNumerically))
 		matcher.Args = []ast.Expr{
 			&ast.BasicLit{Kind: token.STRING, Value: fmt.Sprintf(`"%s"`, op.String())},
@@ -1071,4 +1074,14 @@ func isInterface(pass *analysis.Pass, expr ast.Expr) bool {
 	t := pass.TypesInfo.TypeOf(expr)
 	_, ok := t.(*gotypes.Named)
 	return ok
+}
+
+func isNumeric(pass *analysis.Pass, node ast.Expr) bool {
+	t := pass.TypesInfo.TypeOf(node)
+
+	switch t.String() {
+	case "int", "uint", "int8", "uint8", "int16", "uint16", "int32", "uint32", "int64", "uint64", "float32", "float64":
+		return true
+	}
+	return false
 }

--- a/testdata/src/a/comparison/string_non_equal.go
+++ b/testdata/src/a/comparison/string_non_equal.go
@@ -1,0 +1,14 @@
+package comparison
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("string comparison", func() {
+	It("should not trigger warning for string non-equal comparison ", func() {
+		a, b := "aaa", "bbb"
+		Expect(a < b).To(BeTrue())
+		Expect(a < "bbb").To(BeTrue())
+	})
+})


### PR DESCRIPTION
# Description
Fix bug where when comparing two strings with non-equal sign (e.g. `<` or `>=`), the linter wrongly triggered a warning and suggested to use `BeNumerically`.

Fixes #82

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Added test case and related test data
- [x] Update the functional test

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)

