### PR TITLE
New Rule: Missing Assertion Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,20 @@ In the case above, the linter will suggest `Expect(pNum).ShouldNot(HaveValue(Equ
 This is also right for additional matchers: `BeTrue()` and `BeFalse()`, `BeIdenticalTo()`, `BeEquivalentTo()` 
 and `BeNumerically`.
 
+### Missing Assertion Method
+The linter warns when calling an "actual" method (e.g. `Expect()`, `Eventually()` etc.), without an assertion method (e.g 
+`Should()`, `NotTo()` etc.)
+
+For example:
+```go
+// no assertion for the result
+Eventually(doSomething).WithTimeout(time.Seconds * 5).WithPolling(time.Milliseconds * 100)
+```
+
+The linter will not suggest a fix for this warning.
+
+This rule cannot be suppressed.
+
 ## Suppress the linter
 ### Suppress warning from command line
 * Use the `--suppress-len-assertion=true` flag to suppress the wrong length assertion warning

--- a/ginkgo_linter_test.go
+++ b/ginkgo_linter_test.go
@@ -69,6 +69,10 @@ func TestAllUseCases(t *testing.T) {
 			testName: "compare pointer to value",
 			testData: "a/pointerval",
 		},
+		{
+			testName: "no assertion",
+			testData: "a/noassersion",
+		},
 	} {
 		t.Run(tc.testName, func(tt *testing.T) {
 			analysistest.Run(tt, analysistest.TestData(), ginkgolinter.NewAnalyzer(), tc.testData)
@@ -111,11 +115,6 @@ func TestFlags(t *testing.T) {
 			testName: "test the suppress-async-assertion flag",
 			testData: []string{"a/asyncconfig"},
 			flags:    []string{"suppress-async-assertion"},
-		},
-		{
-			testName: "supress all",
-			testData: []string{"a/configlen", "a/confignil", "a/configerr", "a/havelen0config"},
-			flags:    []string{"suppress-len-assertion", "suppress-nil-assertion", "suppress-err-assertion", "suppress-compare-assertion", "suppress-async-assertion"},
 		},
 	} {
 		t.Run(tc.testName, func(tt *testing.T) {

--- a/testdata/src/a/noassersion/ginkgo.go
+++ b/testdata/src/a/noassersion/ginkgo.go
@@ -1,0 +1,19 @@
+package noassersion
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("", func() {
+	It("should not allow expecting without assertion", func() {
+		Expect("aaa")                                                                           // want `ginkgo-linter: "Expect": missing assertion method. Expected "Should\(\)", "To\(\)", "ShouldNot\(\)", "ToNot\(\)" or "NotTo\(\)"`
+		Eventually(func() {}, 100*time.Millisecond, 10*time.Millisecond)                        //want `ginkgo-linter: "Eventually": missing assertion method. Expected "Should\(\)" or "ShouldNot\(\)"`
+		Eventually(func() {}).Within(100 * time.Millisecond).WithPolling(10 * time.Millisecond) // want `ginkgo-linter: "Eventually": missing assertion method. Expected "Should\(\)" or "ShouldNot\(\)"`
+		Consistently(func() bool { return true })                                               // want `ginkgo-linter: "Consistently": missing assertion method. Expected "Should\(\)" or "ShouldNot\(\)"`
+		EventuallyWithOffset(1, func(g Gomega) { g.Expect(true) }).WithTimeout(2 * time.Second) // want `ginkgo-linter: "EventuallyWithOffset": missing assertion method. Expected "Should\(\)" or "ShouldNot\(\)"` `ginkgo-linter: "Expect": missing assertion method. Expected "Should\(\)", "To\(\)", "ShouldNot\(\)", "ToNot\(\)" or "NotTo\(\)"`
+		ConsistentlyWithOffset(2, func() bool { return true })                                  // want `ginkgo-linter: "ConsistentlyWithOffset": missing assertion method. Expected "Should\(\)" or "ShouldNot\(\)"`
+	})
+})

--- a/testdata/src/a/noassersion/gomagaimport.go
+++ b/testdata/src/a/noassersion/gomagaimport.go
@@ -1,0 +1,28 @@
+package noassersion
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	g "github.com/onsi/gomega"
+)
+
+var _ = Describe("", func() {
+	It("should not allow expecting without assertion", func() {
+		g.Expect("bbbb") // want `ginkgo-linter: "Expect": missing assertion method. Expected "Should\(\)", "To\(\)", "ShouldNot\(\)", "ToNot\(\)" or "NotTo\(\)"`
+
+		g.Eventually( // want `ginkgo-linter: "Eventually": missing assertion method. Expected "Should\(\)" or "ShouldNot\(\)"`
+			func(gg g.Gomega) {
+				gg.Expect(nil) // want `ginkgo-linter: "Expect": missing assertion method. Expected "Should\(\)", "To\(\)", "ShouldNot\(\)", "ToNot\(\)" or "NotTo\(\)"`
+			},
+		).Within(time.Second).
+			WithPolling(time.Millisecond * 100).
+			WithArguments(1).
+			WithContext(context.Background())
+
+		g.Consistently(func(gg g.Gomega) { gg.Expect(nil) }).Within(time.Second).WithPolling(time.Millisecond * 100).WithArguments(1).WithContext(context.Background())              // want `ginkgo-linter: "Consistently": missing assertion method. Expected "Should\(\)" or "ShouldNot\(\)"` `ginkgo-linter: "Expect": missing assertion method. Expected "Should\(\)", "To\(\)", "ShouldNot\(\)", "ToNot\(\)" or "NotTo\(\)"`
+		g.EventuallyWithOffset(1, func(gg g.Gomega) { gg.Expect(nil) }).Within(time.Second).WithPolling(time.Millisecond * 100).WithArguments(1).WithContext(context.Background())   // want `ginkgo-linter: "EventuallyWithOffset": missing assertion method. Expected "Should\(\)" or "ShouldNot\(\)"` `ginkgo-linter: "Expect": missing assertion method. Expected "Should\(\)", "To\(\)", "ShouldNot\(\)", "ToNot\(\)" or "NotTo\(\)"`
+		g.ConsistentlyWithOffset(1, func(gg g.Gomega) { gg.Expect(nil) }).Within(time.Second).WithPolling(time.Millisecond * 100).WithArguments(1).WithContext(context.Background()) // want `ginkgo-linter: "ConsistentlyWithOffset": missing assertion method. Expected "Should\(\)" or "ShouldNot\(\)"` `ginkgo-linter: "Expect": missing assertion method. Expected "Should\(\)", "To\(\)", "ShouldNot\(\)", "ToNot\(\)" or "NotTo\(\)"`
+	})
+})

--- a/testdata/src/a/noassersion/gomega_test.go
+++ b/testdata/src/a/noassersion/gomega_test.go
@@ -1,0 +1,17 @@
+package noassersion
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestGomega(t *testing.T) {
+	g := NewWithT(t)
+
+	g.Expect("aaa")                       // want `ginkgo-linter: "Expect": missing assertion method. Expected "Should\(\)", "To\(\)", "ShouldNot\(\)", "ToNot\(\)" or "NotTo\(\)"`
+	g.Expect("aaa").WithOffset(1)         // want `ginkgo-linter: "Expect": missing assertion method. Expected "Should\(\)", "To\(\)", "ShouldNot\(\)", "ToNot\(\)" or "NotTo\(\)"`
+	g.Expect("aaa").WithOffset(1).Error() // want `ginkgo-linter: "Expect": missing assertion method. Expected "Should\(\)", "To\(\)", "ShouldNot\(\)", "ToNot\(\)" or "NotTo\(\)"`
+
+	g.Eventually(func(gg Gomega) { gg.Expect(true) }) // want `ginkgo-linter: "Eventually": missing assertion method. Expected "Should\(\)" or "ShouldNot\(\)"` `ginkgo-linter: "Expect": missing assertion method. Expected "Should\(\)", "To\(\)", "ShouldNot\(\)", "ToNot\(\)" or "NotTo\(\)"`
+}

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -6,18 +6,18 @@ cp ginkgolinter testdata/src/a
 cd testdata/src/a
 
 # no suppress
-[[ $(./ginkgolinter a/... 2>&1 | wc -l) == 2351 ]]
+[[ $(./ginkgolinter a/... 2>&1 | wc -l) == 2372 ]]
 # suppress all but nil
-[[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 1432 ]]
+[[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 1453 ]]
 # suppress all but len
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 720 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 741 ]]
 # suppress all but err
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 191 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 212 ]]
 # suppress all but compare
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 201 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 222 ]]
 # suppress all but async
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true a/... 2>&1 | wc -l) == 98 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true a/... 2>&1 | wc -l) == 120 ]]
 # allow HaveLen(0)
-[[ $(./ginkgolinter --allow-havelen-0=true a/... 2>&1 | wc -l) == 2338 ]]
-# suppress all - should do nothing
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 0 ]]
+[[ $(./ginkgolinter --allow-havelen-0=true a/... 2>&1 | wc -l) == 2359 ]]
+# suppress all - should only return the few non-suppressble
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 88 ]]


### PR DESCRIPTION
## Description
The linter warns when calling an "actual" method (e.g. `Expect()`, `Eventually()` etc.), without an assertion method (e.g `Should()`, `NotTo()` etc.)

For example:

```go
// no assertion for the result
Eventually(doSomething).WithTimeout(time.Seconds * 5).WithPolling(time.Milliseconds * 100)
```

The linter will not suggest a fix for this warning.

This rule cannot be suppressed.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added test case and related test data
- [X] Update the functional test

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)

