### PR TITLE
Fix bug: false positive warning for typed function calls

### DIFF
--- a/testdata/src/a/eventually/eventuallyFunc.go
+++ b/testdata/src/a/eventually/eventuallyFunc.go
@@ -9,6 +9,14 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+type GetFunc[T any] func(ctx context.Context) (T, error)
+
+func retFuncType() GetFunc[int] {
+	return func(_ context.Context) (int, error) {
+		return 1, nil
+	}
+}
+
 func slowInt() int {
 	time.Sleep(time.Second)
 	return 42
@@ -46,6 +54,10 @@ func retChan() chan int {
 
 var _ = Describe("Eventually with function", func() {
 	Context("Eventually", func() {
+		It("should not trigger warning", func() {
+			Eventually(retFuncType()).Should(Equal(1))
+		})
+
 		Eventually(retFunc(5)).Should(Equal(5)) // valid. retFunc returns a function
 		ch := make(chan int)
 		Eventually(ch).Should(BeClosed())                                                                                        // valid


### PR DESCRIPTION
# Description
When calling a function that return a type in the async assertion (eventually/constantly) body, if this type is a function, the linter fails to recognize it and fire a warning.

This PR fixes this bug, by checking the underline types.

Fixes #91

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added test case and related test data
- [ ] Update the functional test

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [X] I ran [golangci-lint](https://github.com/golangci/golangci-lint)

@nunnatsa
