### PR TITLE
Add new rule: disallow focus containers

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: 1.19
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ It is not enabled by default, though. There are two ways to run ginkgolinter wit
        - ginkgolinter
    ```
 ## Linter Checks
-The linter checks the gomega assertions in golang test code. Gomega may be used together with ginkgo tests, For example:
+The linter checks the ginkgo and gomega assertions in golang test code. Gomega may be used together with ginkgo tests, 
+For example:
 ```go
 It("should test something", func() { // It is ginkgo test case function
 	Expect("abcd").To(HaveLen(4), "the string should have a length of 4") // Expect is the gomega assertion
@@ -71,7 +72,105 @@ The linter checks the `Expect`, `ExpectWithOffset` and the `Ω` "actual" functio
 
 It also supports the embedded `Not()` matcher
 
-### Wrong Length Assertion
+Some checks find actual bugs, and some are more for style.
+
+### Using a function call in async assertion [BUG]
+This rule finds an actual bug in tests, where asserting a function call in an async function; e.g. `Eventually`. For
+example:
+```go
+func slowInt(int val) int {
+	time.Sleep(time.Second)
+	return val
+}
+
+...
+
+It("should test that slowInt returns 42, eventually", func() {
+	Eventually(slowInt(42)).WithPolling(time.Millisecond * 100).WithTimeout(time.Second * 2).Equal(42)
+})
+```
+The problem with the above code is that it **should** poll - call the function - until it returns 42, but what actually
+happens is that first the function is called, and we pass `42` to `Eventually` - not the function. This is not what we
+tried to do here.
+
+The linter will suggest replacing this code by:
+```go
+It("should test that slowInt returns 42, eventually", func() {
+	Eventually(slowInt).WithArguments(42).WithPolling(time.Millisecond * 100).WithTimeout(time.Second * 2).Equal(42)
+})
+```
+
+The linter suggested replacing the function call by the function name.
+
+If function arguments are used, the linter will add the `WithArguments()` method to pass them.
+
+Please notice that `WithArguments()` is only supported from gomenga v1.22.0.
+
+When using an older version of gomega, change the code manually. For example:
+
+```go
+It("should test that slowInt returns 42, eventually", func() {
+	Eventually(func() int {
+		slowint(42)		
+	}).WithPolling(time.Millisecond * 100).WithTimeout(time.Second * 2).Equal(42)
+})
+```
+
+### Comparing a pointer with a value [BUG]
+The linter warns when comparing a pointer with a value.
+These comparisons are always wrong and will always fail.
+
+In case of a positive assertion (`To()` or `Should()`), the test will just fail.
+
+But the main concern is for false positive tests, when using a negative assertion (`NotTo()`, `ToNot()`, `ShouldNot()`,
+`Should(Not())` etc.); e.g.
+```go
+num := 5
+...
+pNum := &num
+...
+Expect(pNum).ShouldNot(Equal(6))
+```
+This assertion will pass, but for the wrong reasons: pNum is not equal 6, not because num == 5, but because pNum is
+a pointer, while `6` is an `int`.
+
+In the case above, the linter will suggest `Expect(pNum).ShouldNot(HaveValue(Equal(6)))`
+
+This is also right for additional matchers: `BeTrue()` and `BeFalse()`, `BeIdenticalTo()`, `BeEquivalentTo()`
+and `BeNumerically`.
+
+### Missing Assertion Method [BUG]
+The linter warns when calling an "actual" method (e.g. `Expect()`, `Eventually()` etc.), without an assertion method (e.g
+`Should()`, `NotTo()` etc.)
+
+For example:
+```go
+// no assertion for the result
+Eventually(doSomething).WithTimeout(time.Seconds * 5).WithPolling(time.Milliseconds * 100)
+```
+
+The linter will not suggest a fix for this warning.
+
+This rule cannot be suppressed.
+
+### Focus Container Found [BUG]
+This rule finds ginkgo focus containers in the code.
+
+ginkgo supports the `FDescribe`, `FContext`, `FWhen` and `FIt` containers to allow the developer to focus
+on a specific test or set of tests during test development or debug.
+
+For example:
+```go
+var _ = Describe("checking something", func() {
+	FIt("this test is the only one that will run", func(){
+		...
+	})
+})
+```
+
+These container must not be part of the final source code, and should only be used locally by the developer.
+
+### Wrong Length Assertion [STYLE]
 The linter finds assertion of the golang built-in `len` function, with all kind of matchers, while there are already gomega matchers for these usecases; We want to assert the item, rather than its length.
 
 There are several wrong patterns:
@@ -102,10 +201,10 @@ The output of the linter,when finding issues, looks like this:
 ./testdata/src/a/a.go:18:5: ginkgo-linter: wrong length assertion; consider using `Expect("").Should(BeEmpty())` instead
 ./testdata/src/a/a.go:22:5: ginkgo-linter: wrong length assertion; consider using `Expect("").Should(BeEmpty())` instead
 ```
-#### use the `HaveLen(0)` matcher. 
+#### use the `HaveLen(0)` matcher.  [STYLE]
 The linter will also warn about the `HaveLen(0)` matcher, and will suggest to replace it with `BeEmpty()`
 
-### Wrong `nil` Assertion
+### Wrong `nil` Assertion [STYLE]
 The linter finds assertion of the comparison to nil, with all kind of matchers, instead of using the existing `BeNil()` matcher; We want to assert the item, rather than a comparison result.
 
 There are several wrong patterns:
@@ -127,7 +226,7 @@ Or even (double negative):
 
 `Ω(x != nil).Should(Not(BeTrue()))` => `Ω(x).Should(BeNil())`
 
-### Wrong boolean Assertion
+### Wrong boolean Assertion [STYLE]
 The linter finds assertion using the `Equal` method, with the values of to `true` or `false`, instead
 of using the existing `BeTrue()` or `BeFalse()` matcher.
 
@@ -141,7 +240,7 @@ It also supports the embedded `Not()` matcher; e.g.
 
 `Ω(x).Should(Not(Equal(True)))` => `Ω(x).ShouldNot(BeTrue())`
 
-### Wrong Error Assertion
+### Wrong Error Assertion [STYLE]
 The linter finds assertion of errors compared with nil, or to be equal nil, or to be nil. The linter suggests to use `Succeed` for functions or `HaveOccurred` for error values..
 
 There are several wrong patterns:
@@ -159,7 +258,7 @@ It also supports the embedded `Not()` matcher; e.g.
 
 `Ω(err == nil).Should(Not(BeTrue()))` => `Ω(x).Should(HaveOccurred())`
 
-### Wrong Comparison Assertion
+### Wrong Comparison Assertion [STYLE]
 The linter finds assertion of boolean comparisons, which are already supported by existing gomega matchers. 
 
 The linter assumes that when compared something to literals or constants, these values should be used for the assertion,
@@ -198,85 +297,6 @@ Expect(x1 == c1).Should(BeTrue()) // ==> Expect(x1).Should(Equal(c1))
 Expect(c1 == x1).Should(BeTrue()) // ==> Expect(x1).Should(Equal(c1))
 ```
 
-### Using a function call in async assertion
-This rule finds an actual bug in tests, where asserting a function call in an async function; e.g. `Eventually`. For
-example:
-```go
-func slowInt(int val) int {
-	time.Sleep(time.Second)
-	return val
-}
-
-...
-
-It("should test that slowInt returns 42, eventually", func() {
-	Eventually(slowInt(42)).WithPolling(time.Millisecond * 100).WithTimeout(time.Second * 2).Equal(42)
-})
-```
-The problem with the above code is that it **should** poll - call the function - until it returns 42, but what actually 
-happens is that first the function is called, and we pass `42` to `Eventually` - not the function. This is not what we 
-tried to do here.
-
-The linter will suggest replacing this code by:
-```go
-It("should test that slowInt returns 42, eventually", func() {
-	Eventually(slowInt).WithArguments(42).WithPolling(time.Millisecond * 100).WithTimeout(time.Second * 2).Equal(42)
-})
-```
-
-The linter suggested replacing the function call by the function name. 
-
-If function arguments are used, the linter will add the `WithArguments()` method to pass them.
-
-Please notice that `WithArguments()` is only supported from gomenga v1.22.0.
-
-When using an older version of gomega, change the code manually. For example:
-
-```go
-It("should test that slowInt returns 42, eventually", func() {
-	Eventually(func() int {
-		slowint(42)		
-	}).WithPolling(time.Millisecond * 100).WithTimeout(time.Second * 2).Equal(42)
-})
-```
-
-### Comparing a pointer with a value
-The linter warns when comparing a pointer with a value.
-These comparisons are always wrong and will always fail.
-
-In case of a positive assertion (`To()` or `Should()`), the test will just fail.
-
-But the main concern is for false positive tests, when using a negative assertion (`NotTo()`, `ToNot()`, `ShouldNot()`,
-`Should(Not())` etc.); e.g.
-```go
-num := 5
-...
-pNum := &num
-...
-Expect(pNum).ShouldNot(Equal(6))
-```
-This assertion will pass, but for the wrong reasons: pNum is not equal 6, not because num == 5, but because pNum is
-a pointer, while `6` is an `int`.
-
-In the case above, the linter will suggest `Expect(pNum).ShouldNot(HaveValue(Equal(6)))`
-
-This is also right for additional matchers: `BeTrue()` and `BeFalse()`, `BeIdenticalTo()`, `BeEquivalentTo()` 
-and `BeNumerically`.
-
-### Missing Assertion Method
-The linter warns when calling an "actual" method (e.g. `Expect()`, `Eventually()` etc.), without an assertion method (e.g 
-`Should()`, `NotTo()` etc.)
-
-For example:
-```go
-// no assertion for the result
-Eventually(doSomething).WithTimeout(time.Seconds * 5).WithPolling(time.Milliseconds * 100)
-```
-
-The linter will not suggest a fix for this warning.
-
-This rule cannot be suppressed.
-
 ## Suppress the linter
 ### Suppress warning from command line
 * Use the `--suppress-len-assertion=true` flag to suppress the wrong length assertion warning
@@ -284,6 +304,7 @@ This rule cannot be suppressed.
 * Use the `--suppress-err-assertion=true` flag to suppress the wrong error assertion warning
 * Use the `--suppress-compare-assertion=true` flag to suppress the wrong comparison assertion warning
 * Use the `--suppress-async-assertion=true` flag to suppress the function call in async assertion warning
+* Use the `--suppress-focus-container=true` flag to suppress the focus container warning
 * Use the `--allow-havelen-0=true` flag to avoid warnings about `HaveLen(0)`; Note: this parameter is only supported from
   command line, and not from a comment.
 
@@ -307,6 +328,17 @@ To suppress the wrong comparison assertion warning, add a comment with (only)
 To suppress the wrong async assertion warning, add a comment with (only)
 
 `ginkgo-linter:ignore-async-assert-warning`. 
+
+To supress the focus container warning, add a comment with (only)
+
+`ginkgo-linter:ignore-focus-container-warning`
+
+Notice that this comment will not work for an anonymous variable container like
+```go
+// ginkgo-linter:ignore-focus-container-warning (not working!!)
+var _ = FDescribe(...)
+```
+In this case, use the file comment (see bellow).
 
 There are two options to use these comments:
 1. If the comment is at the top of the file, supress the warning for the whole file; e.g.:

--- a/ginkgo_linter_test.go
+++ b/ginkgo_linter_test.go
@@ -73,6 +73,10 @@ func TestAllUseCases(t *testing.T) {
 			testName: "no assertion",
 			testData: "a/noassersion",
 		},
+		{
+			testName: "focus",
+			testData: "a/focus",
+		},
 	} {
 		t.Run(tc.testName, func(tt *testing.T) {
 			analysistest.Run(tt, analysistest.TestData(), ginkgolinter.NewAnalyzer(), tc.testData)
@@ -115,6 +119,11 @@ func TestFlags(t *testing.T) {
 			testName: "test the suppress-async-assertion flag",
 			testData: []string{"a/asyncconfig"},
 			flags:    []string{"suppress-async-assertion"},
+		},
+		{
+			testName: "test the suppress-focus-container flag",
+			testData: []string{"a/focusconfig"},
+			flags:    []string{"suppress-focus-container"},
 		},
 	} {
 		t.Run(tc.testName, func(tt *testing.T) {

--- a/ginkgohandler/handler.go
+++ b/ginkgohandler/handler.go
@@ -1,0 +1,66 @@
+package ginkgohandler
+
+import (
+	"go/ast"
+)
+
+// Handler provide different handling, depend on the way ginkgo was imported, whether
+// in imported with "." name, custom name or without any name.
+type Handler interface {
+	GetFocusContainerName(*ast.CallExpr) (bool, *ast.Ident)
+}
+
+// GetGinkgoHandler returns a ginkgor handler according to the way ginkgo was imported in the specific file
+func GetGinkgoHandler(file *ast.File) Handler {
+	for _, imp := range file.Imports {
+		if imp.Path.Value != `"github.com/onsi/ginkgo"` && imp.Path.Value != `"github.com/onsi/ginkgo/v2"` {
+			continue
+		}
+
+		switch name := imp.Name.String(); {
+		case name == ".":
+			return dotHandler{}
+		case name == "<nil>": // import with no local name
+			return nameHandler("ginkgo")
+		default:
+			return nameHandler(name)
+		}
+	}
+
+	return nil // no ginkgo import; this file does not use ginkgo
+}
+
+// dotHandler is used when importing ginkgo with dot; i.e.
+// import . "github.com/onsi/ginkgo"
+type dotHandler struct{}
+
+func (h dotHandler) GetFocusContainerName(exp *ast.CallExpr) (bool, *ast.Ident) {
+	if fun, ok := exp.Fun.(*ast.Ident); ok {
+		return isFocusContainer(fun.Name), fun
+	}
+	return false, nil
+}
+
+// nameHandler is used when importing ginkgo without name; i.e.
+// import "github.com/onsi/ginkgo"
+//
+// or with a custom name; e.g.
+// import customname "github.com/onsi/ginkgo"
+type nameHandler string
+
+func (h nameHandler) GetFocusContainerName(exp *ast.CallExpr) (bool, *ast.Ident) {
+	if sel, ok := exp.Fun.(*ast.SelectorExpr); ok {
+		if id, ok := sel.X.(*ast.Ident); ok && id.Name == string(h) {
+			return isFocusContainer(sel.Sel.Name), sel.Sel
+		}
+	}
+	return false, nil
+}
+
+func isFocusContainer(name string) bool {
+	switch name {
+	case "FDescribe", "FContext", "FWhen", "FIt":
+		return true
+	}
+	return false
+}

--- a/ginkgohandler/handler_test.go
+++ b/ginkgohandler/handler_test.go
@@ -1,0 +1,112 @@
+package ginkgohandler
+
+import (
+	"go/ast"
+	"testing"
+)
+
+var imports = []string{`"github.com/onsi/ginkgo"`, `"github.com/onsi/ginkgo/v2"`}
+
+func TestGetGinkgoHandler_dot(t *testing.T) {
+	for _, imp := range imports {
+		t.Run("TestGetGinkgoHandler_dot: "+imp, func(tt *testing.T) {
+			name := ast.NewIdent("test.go")
+			file := &ast.File{
+				Name: name,
+				Imports: []*ast.ImportSpec{
+					{
+						Name: ast.NewIdent("."),
+						Path: &ast.BasicLit{Value: imp},
+					},
+				},
+			}
+
+			h := GetGinkgoHandler(file)
+			if h == nil {
+				tt.Fatalf("should return dotHandler")
+			}
+			_, ok := h.(dotHandler)
+			if !ok {
+				tt.Error("should return dotHandler")
+			}
+		})
+	}
+}
+
+func TestGetGinkgoHandler_noname(t *testing.T) {
+	for _, imp := range imports {
+		t.Run("TestGetGinkgoHandler_noname: "+imp, func(tt *testing.T) {
+			name := ast.NewIdent("test.go")
+			file := &ast.File{
+				Name: name,
+				Imports: []*ast.ImportSpec{
+					{
+						Path: &ast.BasicLit{Value: imp},
+					},
+				},
+			}
+
+			h := GetGinkgoHandler(file)
+			if h == nil {
+				tt.Fatalf("should return nameHandler")
+			}
+			n, ok := h.(nameHandler)
+			if !ok {
+				tt.Error("should return nameHandler")
+			}
+
+			if string(n) != "ginkgo" {
+				tt.Errorf("import name should be `ginkgo`, but it's %s", string(n))
+			}
+
+		})
+	}
+}
+
+func TestGetGinkgoHandler_name(t *testing.T) {
+	for _, imp := range imports {
+		t.Run("TestGetGinkgoHandler_name: "+imp, func(tt *testing.T) {
+			name := ast.NewIdent("test.go")
+			file := &ast.File{
+				Name: name,
+				Imports: []*ast.ImportSpec{
+					{
+						Name: ast.NewIdent("name"),
+						Path: &ast.BasicLit{Value: `"github.com/onsi/ginkgo"`},
+					},
+				},
+			}
+
+			h := GetGinkgoHandler(file)
+			if h == nil {
+				tt.Fatalf("should return nameHandler")
+			}
+			n, ok := h.(nameHandler)
+			if !ok {
+				tt.Error("should return nameHandler")
+			}
+
+			if string(n) != "name" {
+				tt.Errorf("import name should be `name`, but it's %s", string(n))
+			}
+		})
+	}
+}
+
+func TestGetGinkgoHandler_no_ginkgo(t *testing.T) {
+	name := ast.NewIdent("test.go")
+	file := &ast.File{
+		Name: name,
+		Imports: []*ast.ImportSpec{
+			{
+				Name: ast.NewIdent("."),
+				Path: &ast.BasicLit{Value: `"github.com/onsi/gomega"`},
+			},
+		},
+	}
+
+	h := GetGinkgoHandler(file)
+	if h != nil {
+		t.Fatalf("should return nil")
+	}
+}

--- a/testdata/src/a/focus/focus_name_test.go
+++ b/testdata/src/a/focus/focus_name_test.go
@@ -1,0 +1,55 @@
+package focus
+
+import (
+	tester "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = tester.FDescribe("should warn", func() { // want `ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with "Describe"`
+	tester.When("should ignore", func() {
+		tester.It("should ignore", func() {
+			Expect(len("abcd")).Should(Equal(4)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.Should\(HaveLen\(4\)\). instead`
+		})
+	})
+	tester.Context("should ignore", func() {
+		tester.It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+
+	tester.It("should ignore", func() {
+		Expect("abcd").Should(HaveLen(4))
+	})
+})
+
+var _ = tester.Describe("should ignore", func() {
+	tester.FWhen("should warn", func() { // want `ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with "When"`
+		tester.Context("should ignore", func() {
+			tester.It("should ignore", func() {
+				Expect("abcd").Should(HaveLen(4))
+			})
+		})
+
+		tester.It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+
+	tester.FContext("should warn", func() { // want `ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with "Context"`
+		tester.Context("should ignore", func() {
+			tester.It("should ignore", func() {
+				Expect("abcd").Should(HaveLen(4))
+			})
+		})
+
+		tester.It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+
+	tester.Context("ignore", func() {
+		tester.FIt("should warn", func() { // want `ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with "It"`
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+})

--- a/testdata/src/a/focus/focus_noname_test.go
+++ b/testdata/src/a/focus/focus_noname_test.go
@@ -1,0 +1,55 @@
+package focus
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.FDescribe("should warn", func() { // want `ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with "Describe"`
+	ginkgo.When("should ignore", func() {
+		ginkgo.It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+	ginkgo.Context("should ignore", func() {
+		ginkgo.It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+
+	ginkgo.It("should ignore", func() {
+		Expect("abcd").Should(HaveLen(4))
+	})
+})
+
+var _ = ginkgo.Describe("should ignore", func() {
+	ginkgo.FWhen("should warn", func() { // want `ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with "When"`
+		ginkgo.Context("should ignore", func() {
+			ginkgo.It("should ignore", func() {
+				Expect("abcd").Should(HaveLen(4))
+			})
+		})
+
+		ginkgo.It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+
+	ginkgo.FContext("should warn", func() { // want `ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with "Context"`
+		ginkgo.Context("should ignore", func() {
+			ginkgo.It("should ignore", func() {
+				Expect("abcd").Should(HaveLen(4))
+			})
+		})
+
+		ginkgo.It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+
+	ginkgo.Context("ignore", func() {
+		ginkgo.FIt("should warn", func() { // want `ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with "It"`
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+})

--- a/testdata/src/a/focus/focus_test.go
+++ b/testdata/src/a/focus/focus_test.go
@@ -1,0 +1,68 @@
+package focus
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = FDescribe("should warn", func() { // want `ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with "Describe"`
+	When("should ignore", func() {
+		It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+	Context("should ignore", func() {
+		It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+
+	It("should ignore", func() {
+		Expect("abcd").Should(HaveLen(4))
+	})
+})
+
+var _ = Describe("should ignore", func() {
+	FWhen("should warn", func() { // want `ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with "When"`
+		Context("should ignore", func() {
+			It("should ignore", func() {
+				Expect("abcd").Should(HaveLen(4))
+			})
+		})
+
+		It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+
+	FContext("should warn", func() { // want `ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with "Context"`
+		Context("should ignore", func() {
+			It("should ignore", func() {
+				Expect("abcd").Should(HaveLen(4))
+			})
+		})
+
+		It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+
+	Context("ignore", func() {
+		FIt("should warn", func() { // want `ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with "It"`
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+})
+
+var _ = Describe("suppress", func() {
+	// ginkgo-linter:ignore-focus-container-warning
+	FContext("supress", func() {
+		// ginkgo-linter:ignore-focus-container-warning
+		FWhen("suppress", func() {
+			// ginkgo-linter:ignore-focus-container-warning
+			FIt("suppress", func() {
+				Expect(len("abcd")).Should(Equal(4)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.Should\(HaveLen\(4\)\). instead`
+			})
+		})
+	})
+})

--- a/testdata/src/a/focus/supress_test.go
+++ b/testdata/src/a/focus/supress_test.go
@@ -1,0 +1,57 @@
+package focus
+
+// ginkgo-linter:ignore-focus-container-warning
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = FDescribe("should warn", func() {
+	When("should ignore", func() {
+		It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+	Context("should ignore", func() {
+		It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+
+	It("should ignore", func() {
+		Expect("abcd").Should(HaveLen(4))
+	})
+})
+
+var _ = Describe("should ignore", func() {
+	FWhen("should warn", func() {
+		Context("should ignore", func() {
+			It("should ignore", func() {
+				Expect("abcd").Should(HaveLen(4))
+			})
+		})
+
+		It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+
+	FContext("should warn", func() {
+		Context("should ignore", func() {
+			It("should ignore", func() {
+				Expect("abcd").Should(HaveLen(4))
+			})
+		})
+
+		It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+
+	Context("ignore", func() {
+		FIt("should warn", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+})

--- a/testdata/src/a/focusconfig/focus_name_test.go
+++ b/testdata/src/a/focusconfig/focus_name_test.go
@@ -1,0 +1,55 @@
+package focus
+
+import (
+	tester "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = tester.FDescribe("should warn", func() {
+	tester.When("should ignore", func() {
+		tester.It("should ignore", func() {
+			Expect(len("abcd")).Should(Equal(4)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("abcd"\)\.Should\(HaveLen\(4\)\). instead`
+		})
+	})
+	tester.Context("should ignore", func() {
+		tester.It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+
+	tester.It("should ignore", func() {
+		Expect("abcd").Should(HaveLen(4))
+	})
+})
+
+var _ = tester.Describe("should ignore", func() {
+	tester.FWhen("should warn", func() {
+		tester.Context("should ignore", func() {
+			tester.It("should ignore", func() {
+				Expect("abcd").Should(HaveLen(4))
+			})
+		})
+
+		tester.It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+
+	tester.FContext("should warn", func() {
+		tester.Context("should ignore", func() {
+			tester.It("should ignore", func() {
+				Expect("abcd").Should(HaveLen(4))
+			})
+		})
+
+		tester.It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+
+	tester.Context("ignore", func() {
+		tester.FIt("should warn", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+})

--- a/testdata/src/a/focusconfig/focus_noname_test.go
+++ b/testdata/src/a/focusconfig/focus_noname_test.go
@@ -1,0 +1,55 @@
+package focus
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.FDescribe("should warn", func() {
+	ginkgo.When("should ignore", func() {
+		ginkgo.It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+	ginkgo.Context("should ignore", func() {
+		ginkgo.It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+
+	ginkgo.It("should ignore", func() {
+		Expect("abcd").Should(HaveLen(4))
+	})
+})
+
+var _ = ginkgo.Describe("should ignore", func() {
+	ginkgo.FWhen("should warn", func() {
+		ginkgo.Context("should ignore", func() {
+			ginkgo.It("should ignore", func() {
+				Expect("abcd").Should(HaveLen(4))
+			})
+		})
+
+		ginkgo.It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+
+	ginkgo.FContext("should warn", func() {
+		ginkgo.Context("should ignore", func() {
+			ginkgo.It("should ignore", func() {
+				Expect("abcd").Should(HaveLen(4))
+			})
+		})
+
+		ginkgo.It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+
+	ginkgo.Context("ignore", func() {
+		ginkgo.FIt("should warn", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+})

--- a/testdata/src/a/focusconfig/focus_test.go
+++ b/testdata/src/a/focusconfig/focus_test.go
@@ -1,0 +1,55 @@
+package focus
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = FDescribe("should warn", func() {
+	When("should ignore", func() {
+		It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+	Context("should ignore", func() {
+		It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+
+	It("should ignore", func() {
+		Expect("abcd").Should(HaveLen(4))
+	})
+})
+
+var _ = Describe("should ignore", func() {
+	FWhen("should warn", func() {
+		Context("should ignore", func() {
+			It("should ignore", func() {
+				Expect("abcd").Should(HaveLen(4))
+			})
+		})
+
+		It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+
+	FContext("should warn", func() {
+		Context("should ignore", func() {
+			It("should ignore", func() {
+				Expect("abcd").Should(HaveLen(4))
+			})
+		})
+
+		It("should ignore", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+
+	Context("ignore", func() {
+		FIt("should warn", func() {
+			Expect("abcd").Should(HaveLen(4))
+		})
+	})
+})

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -6,18 +6,20 @@ cp ginkgolinter testdata/src/a
 cd testdata/src/a
 
 # no suppress
-[[ $(./ginkgolinter a/... 2>&1 | wc -l) == 2371 ]]
+[[ $(./ginkgolinter a/... 2>&1 | wc -l) == 2398 ]]
 # suppress all but nil
-[[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 1452 ]]
+[[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-focus-container=true a/... 2>&1 | wc -l) == 1452 ]]
 # suppress all but len
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 741 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-focus-container=true a/... 2>&1 | wc -l) == 744 ]]
 # suppress all but err
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 212 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-focus-container=true a/... 2>&1 | wc -l) == 212 ]]
 # suppress all but compare
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 222 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-async-assertion=true --suppress-focus-container=true a/... 2>&1 | wc -l) == 222 ]]
 # suppress all but async
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true a/... 2>&1 | wc -l) == 119 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-focus-container=true a/... 2>&1 | wc -l) == 119 ]]
+# suppress all but focus
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 112 ]]
 # allow HaveLen(0)
-[[ $(./ginkgolinter --allow-havelen-0=true a/... 2>&1 | wc -l) == 2358 ]]
+[[ $(./ginkgolinter --allow-havelen-0=true a/... 2>&1 | wc -l) == 2385 ]]
 # suppress all - should only return the few non-suppressble
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 88 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-focus-container=true a/... 2>&1 | wc -l) == 88 ]]

--- a/types/config.go
+++ b/types/config.go
@@ -13,6 +13,7 @@ const (
 	suppressErrAssertionWarning     = suppressPrefix + "ignore-err-assert-warning"
 	suppressCompareAssertionWarning = suppressPrefix + "ignore-compare-assert-warning"
 	suppressAsyncAsertWarning       = suppressPrefix + "ignore-async-assert-warning"
+	suppressFocusContainerWarning   = suppressPrefix + "ignore-focus-container-warning"
 )
 
 type Config struct {
@@ -21,11 +22,12 @@ type Config struct {
 	SuppressErr     Boolean
 	SuppressCompare Boolean
 	SuppressAsync   Boolean
+	SuppressFocus   Boolean
 	AllowHaveLen0   Boolean
 }
 
 func (s *Config) AllTrue() bool {
-	return bool(s.SuppressLen && s.SuppressNil && s.SuppressErr && s.SuppressCompare && s.SuppressAsync)
+	return bool(s.SuppressLen && s.SuppressNil && s.SuppressErr && s.SuppressCompare && s.SuppressAsync && s.SuppressFocus)
 }
 
 func (s *Config) Clone() Config {
@@ -35,6 +37,7 @@ func (s *Config) Clone() Config {
 		SuppressErr:     s.SuppressErr,
 		SuppressCompare: s.SuppressCompare,
 		SuppressAsync:   s.SuppressAsync,
+		SuppressFocus:   s.SuppressFocus,
 		AllowHaveLen0:   s.AllowHaveLen0,
 	}
 }
@@ -58,6 +61,7 @@ func (s *Config) UpdateFromComment(commentGroup []*ast.CommentGroup) {
 				s.SuppressErr = s.SuppressErr || (comment == suppressErrAssertionWarning)
 				s.SuppressCompare = s.SuppressCompare || (comment == suppressCompareAssertionWarning)
 				s.SuppressAsync = s.SuppressAsync || (comment == suppressAsyncAsertWarning)
+				s.SuppressFocus = s.SuppressFocus || (comment == suppressFocusContainerWarning)
 			}
 		}
 	}

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -11,6 +11,7 @@ func TestSuppress_AllTrue(t *testing.T) {
 		SuppressErr:     true,
 		SuppressAsync:   true,
 		SuppressCompare: true,
+		SuppressFocus:   true,
 	}
 
 	if !s.AllTrue() {
@@ -50,6 +51,7 @@ func TestSuppress_Clone(t *testing.T) {
 		SuppressErr:     true,
 		SuppressCompare: true,
 		SuppressAsync:   true,
+		SuppressFocus:   true,
 	}
 
 	clone := s.Clone()


### PR DESCRIPTION
# Description
Focus ginkgo containers (FDescribe, FContext, FWhen, and FIt) should only be used locally, on debug.

This PR introduces a new rule to prevent the leaking of this kind of debug code into the source code in the repo.

New suppress comment to suppress this new rule: `// ginkgo-linter:ignore-focus-container-warning`

New command line flag to suppress this new rule: `--suppress-focus-container`

Fixes https://github.com/kubevirt/kubevirt/issues/10120

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added test case and related test data
- [x] Update the functional test

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)

@nunnatsa
