### PR TITLE
New Rule: should not compare two different types

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,29 @@ These container, or the `Focus` spec, must not be part of the final source code,
 
 ***This rule is disabled by default***. Use the `--forbid-focus-container=true` command line flag to enable it.  
 
+### Comparing values from different types [BUG]
 
+The `Equal` and the `BeIdentical` matchers also check the type, not only the value.
+    
+The following code will fail in runtime:    
+```go
+x := 5 // x is int
+Expect(x).Should(Eqaul(uint(5)) // x and uint(5) are with different
+```
+When using negative checks, it's even worse, because we get a false positive:
+```
+x := 5
+Expect(x).ShouldNot(Equal(uint(5))
+```
+
+The linter suggests two options to solve this warning: either compare with the same type, e.g. 
+using casting, or use the `BeEquivalentTo` matcher.
+
+The linter can't guess what is the best solution in each case, and so it won't auto-fix this warning.
+
+To suppress this warning entirely, use the `--suppress-type-compare-assertion=true` command line parameter. 
+
+To suppress a specific file or line, use the `// ginkgo-linter:ignore-type-compare-warning` comment (see [below](#suppress-warning-from-the-code))
 
 ### Wrong Length Assertion [STYLE]
 The linter finds assertion of the golang built-in `len` function, with all kind of matchers, while there are already gomega matchers for these usecases; We want to assert the item, rather than its length.
@@ -317,6 +339,8 @@ Expect(c1 == x1).Should(BeTrue()) // ==> Expect(x1).Should(Equal(c1))
 * Use the `--suppress-err-assertion=true` flag to suppress the wrong error assertion warning
 * Use the `--suppress-compare-assertion=true` flag to suppress the wrong comparison assertion warning
 * Use the `--suppress-async-assertion=true` flag to suppress the function call in async assertion warning
+* Use the `--forbid-focus-container=true` flag to activate the focused container assertion (deactivated by default)
+* Use the `--suppress-type-compare-assertion=true` to suppress the type compare assertion warning
 * Use the `--allow-havelen-0=true` flag to avoid warnings about `HaveLen(0)`; Note: this parameter is only supported from
   command line, and not from a comment.
 
@@ -344,6 +368,10 @@ To suppress the wrong async assertion warning, add a comment with (only)
 To supress the focus container warning, add a comment with (only)
 
 `ginkgo-linter:ignore-focus-container-warning`
+
+To suppress the different type comparison, add a comment with (only)
+
+`ginkgo-linter:ignore-type-compare-warning`
 
 Notice that this comment will not work for an anonymous variable container like
 ```go

--- a/ginkgo_linter.go
+++ b/ginkgo_linter.go
@@ -9,6 +9,7 @@ import (
 	"go/printer"
 	"go/token"
 	gotypes "go/types"
+	"reflect"
 
 	"github.com/go-toolsmith/astcopy"
 	"golang.org/x/tools/go/analysis"
@@ -38,6 +39,8 @@ const (
 	missingAsyncAssertionMessage  = linterName + `: %q: missing assertion method. Expected "Should()" or "ShouldNot()"`
 	focusContainerFound           = linterName + ": Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with %q"
 	focusSpecFound                = linterName + ": Focus spec found. This is used only for local debug and should not be part of the actual source code, consider to remove it"
+	compareDifferentTypes         = linterName + ": use %[1]s with different types: Comparing %[2]s with %[3]s; either change the expected value type if possible, or use the BeEquivalentTo() matcher, instead of %[1]s()"
+	compareInterfaces             = linterName + ": be careful comparing interfaces. This can fail in runtime, if the actual implementing types are different"
 )
 const ( // gomega matchers
 	beEmpty        = "BeEmpty"
@@ -55,6 +58,9 @@ const ( // gomega matchers
 	not            = "Not"
 	omega          = "Ω"
 	succeed        = "Succeed"
+	and            = "And"
+	or             = "Or"
+	withTransform  = "WithTransform"
 )
 
 const ( // gomega actuals
@@ -99,6 +105,7 @@ func NewAnalyzer() *analysis.Analyzer {
 	a.Flags.Var(&linter.config.SuppressErr, "suppress-err-assertion", "Suppress warning for wrong error assertions")
 	a.Flags.Var(&linter.config.SuppressCompare, "suppress-compare-assertion", "Suppress warning for wrong comparison assertions")
 	a.Flags.Var(&linter.config.SuppressAsync, "suppress-async-assertion", "Suppress warning for function call in async assertion, like Eventually")
+	a.Flags.Var(&linter.config.SuppressTypeCompare, "suppress-type-compare-assertion", "Suppress warning for comparing values from different types, like int32 and uint32")
 	a.Flags.Var(&linter.config.AllowHaveLen0, "allow-havelen-0", "Do not warn for HaveLen(0); default = false")
 
 	a.Flags.BoolVar(&ignored, "suppress-focus-container", true, "Suppress warning for ginkgo focus containers like FDescribe, FContext, FWhen or FIt. Deprecated and ignored: use --forbid-focus-container instead")
@@ -125,6 +132,9 @@ currently, the linter searches for following:
 	Eventually(checkSomething)
 
 * trigger a warning when a ginkgo focus container (FDescribe, FContext, FWhen or FIt) is found. [Bug]
+
+* trigger a warning when using the Equal or the BeIdentical matcher with two different types, as these matchers will
+  fail in runtime.
 
 * wrong length assertions. We want to assert the item rather than its length. [Style]
 For example:
@@ -299,9 +309,119 @@ func checkExpression(pass *analysis.Pass, config types.Config, assertionExp *ast
 
 	} else if checkPointerComparison(pass, config, assertionExp, expr, actualArg, handler, oldExpr) {
 		return false
-	} else {
-		return handleAssertionOnly(pass, config, expr, handler, actualArg, oldExpr, true)
+	} else if !handleAssertionOnly(pass, config, expr, handler, actualArg, oldExpr, true) {
+		return false
+	} else if !config.SuppressTypeCompare {
+		return !checkEqualWrongType(pass, assertionExp, actualArg, handler, oldExpr)
 	}
+
+	return true
+}
+
+func checkEqualWrongType(pass *analysis.Pass, origExp *ast.CallExpr, actualArg ast.Expr, handler gomegahandler.Handler, old string) bool {
+	matcher, ok := origExp.Args[0].(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+
+	return checkEqualDifferentTypes(pass, matcher, actualArg, handler, old, false)
+}
+
+func checkEqualDifferentTypes(pass *analysis.Pass, matcher *ast.CallExpr, actualArg ast.Expr, handler gomegahandler.Handler, old string, parentPointer bool) bool {
+	matcherFuncName, ok := handler.GetActualFuncName(matcher)
+	if !ok {
+		return false
+	}
+
+	switch matcherFuncName {
+	case equal, beIdenticalTo: // continue
+	case and, or:
+		foundIssue := false
+		for _, nestedExp := range matcher.Args {
+			nested, ok := nestedExp.(*ast.CallExpr)
+			if !ok {
+				continue
+			}
+			if checkEqualDifferentTypes(pass, nested, actualArg, handler, old, parentPointer) {
+				foundIssue = true
+			}
+		}
+
+		return foundIssue
+	case withTransform:
+		nested, ok := matcher.Args[1].(*ast.CallExpr)
+		if !ok {
+			return false
+		}
+
+		return checkEqualDifferentTypes(pass, nested, actualArg, handler, old, parentPointer)
+
+	case not:
+		nested, ok := matcher.Args[0].(*ast.CallExpr)
+		if !ok {
+			return false
+		}
+
+		return checkEqualDifferentTypes(pass, nested, actualArg, handler, old, parentPointer)
+
+	case haveValue:
+		nested, ok := matcher.Args[0].(*ast.CallExpr)
+		if !ok {
+			return false
+		}
+
+		return checkEqualDifferentTypes(pass, nested, actualArg, handler, old, true)
+	default:
+		return false
+	}
+
+	matcherValue := matcher.Args[0]
+
+	actualType := pass.TypesInfo.TypeOf(actualArg)
+
+	switch act := actualType.(type) {
+	case *gotypes.Tuple:
+		actualType = act.At(0).Type()
+	case *gotypes.Pointer:
+		if parentPointer {
+			actualType = act.Elem()
+		}
+	}
+
+	matcherType := pass.TypesInfo.TypeOf(matcherValue)
+
+	if !reflect.DeepEqual(matcherType, actualType) {
+		// Equal can handle comparison of interface and a value that implements it
+		if isImplementing(matcherType, actualType) || isImplementing(actualType, matcherType) {
+			return false
+		}
+
+		reportNoFix(pass, matcher.Pos(), compareDifferentTypes, matcherFuncName, actualType, matcherType)
+		return true
+	}
+
+	return false
+}
+
+func isImplementing(ifs, impl gotypes.Type) bool {
+	if gotypes.IsInterface(ifs) {
+
+		var (
+			theIfs *gotypes.Interface
+			ok     bool
+		)
+
+		for {
+			theIfs, ok = ifs.(*gotypes.Interface)
+			if ok {
+				break
+			}
+			ifs = ifs.Underlying()
+		}
+
+		return gotypes.Implements(impl, theIfs)
+	}
+	return false
 }
 
 // be careful - never change origExp!!! only modify its clone, expr!!!
@@ -1181,8 +1301,7 @@ func isPointer(pass *analysis.Pass, expr ast.Expr) bool {
 
 func isInterface(pass *analysis.Pass, expr ast.Expr) bool {
 	t := pass.TypesInfo.TypeOf(expr)
-	_, ok := t.(*gotypes.Named)
-	return ok
+	return gotypes.IsInterface(t)
 }
 
 func isNumeric(pass *analysis.Pass, node ast.Expr) bool {

--- a/ginkgo_linter_test.go
+++ b/ginkgo_linter_test.go
@@ -77,6 +77,10 @@ func TestAllUseCases(t *testing.T) {
 			testName: "focus",
 			testData: "a/focus",
 		},
+		{
+			testName: "equal with different type",
+			testData: "a/comparetypes",
+		},
 	} {
 		t.Run(tc.testName, func(tt *testing.T) {
 			analysistest.Run(tt, analysistest.TestData(), ginkgolinter.NewAnalyzer(), tc.testData)
@@ -124,6 +128,11 @@ func TestFlags(t *testing.T) {
 			testName: "test the forbid-focus-container flag",
 			testData: []string{"a/focusconfig"},
 			flags:    map[string]string{"forbid-focus-container": "true"},
+		},
+		{
+			testName: "test the suppress-type-compare-assertion flag",
+			testData: []string{"a/comparetypesconfig"},
+			flags:    map[string]string{"suppress-type-compare-assertion": "true"},
 		},
 	} {
 		t.Run(tc.testName, func(tt *testing.T) {

--- a/testdata/src/a/comparetypes/comparetypes.gomega_test.go
+++ b/testdata/src/a/comparetypes/comparetypes.gomega_test.go
@@ -1,0 +1,79 @@
+package comparetypes_test
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+func fint64() int64 {
+	return 5
+}
+
+type mytype int
+
+func fmytype() mytype {
+	return 5
+}
+
+func multi() (int64, error) {
+	return 4, nil
+}
+
+type myinf interface {
+	doSomething()
+}
+
+type imp1 int
+
+func (imp1) doSomething() {
+	fmt.Println("doing something")
+}
+
+type imp2 int
+
+func (imp2) doSomething() {
+	fmt.Println("doing something else")
+}
+
+var _ = Describe("compare different types", func() {
+	It("find false positive check", func() {
+		a := 5
+		gomega.Expect(multi()).ShouldNot(gomega.Equal(4)) // want `ginkgo-linter: use Equal with different types: Comparing int64 with int; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		gomega.Expect(a).ShouldNot(gomega.Equal(5))
+		gomega.Expect(a).ShouldNot(gomega.Equal(uint(5)))           // want `ginkgo-linter: use Equal with different types: Comparing int with uint; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		gomega.Expect(fint64()).ShouldNot(gomega.Equal(uint64(5)))  // want `ginkgo-linter: use Equal with different types: Comparing int64 with uint64; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		gomega.Expect(fmytype()).ShouldNot(gomega.Equal(uint64(5))) // want `ginkgo-linter: use Equal with different types: Comparing a/comparetypes_test.mytype with uint64; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		gomega.Expect(a).ShouldNot(gomega.Equal(int32(5)))          // want `ginkgo-linter: use Equal with different types: Comparing int with int32; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		gomega.Expect(a).ShouldNot(gomega.Equal(uint8(5)))          // want `ginkgo-linter: use Equal with different types: Comparing int with uint8; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		gomega.Expect(a).ShouldNot(gomega.Equal(mytype(5)))         // want `ginkgo-linter: use Equal with different types: Comparing int with a/comparetypes_test.mytype; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		gomega.Expect(5).ShouldNot(gomega.Equal(mytype(5)))         // want `ginkgo-linter: use Equal with different types: Comparing int with a/comparetypes_test.mytype; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+
+		b := int16(5)
+		gomega.Expect(a).ShouldNot(gomega.Equal(b)) // want `ginkgo-linter: use Equal with different types: Comparing int with int16; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+
+		c := mytype(5)
+		gomega.Expect(a).ShouldNot(gomega.Equal(c)) // want `ginkgo-linter: use Equal with different types: Comparing int with a/comparetypes_test.mytype; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+	})
+
+	It("compare interfaces", func() {
+		var (
+			a myinf = imp1(3)
+			b myinf = imp2(3)
+		)
+		gomega.Expect(a).ShouldNot(gomega.Equal(b)) // this is not good, but not an error. Should have kind of warning here.
+		gomega.Expect(a).ShouldNot(gomega.BeEquivalentTo(b))
+		gomega.Expect(a).ShouldNot(gomega.BeIdenticalTo(b)) // this is not good, but not an error. Should have kind of warning here.
+	})
+
+	It("check HaveValue(Equal)", func() {
+		a := 5
+		pa := &a
+
+		gomega.Expect(pa).Should(gomega.HaveValue(gomega.Equal(uint64(5))))                                                                // want `ginkgo-linter: use Equal with different types: Comparing int with uint64; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		gomega.Expect(a).Should(gomega.Not(gomega.Equal(uint64(5))))                                                                       // want `ginkgo-linter: use Equal with different types: Comparing int with uint64; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		gomega.Expect(a).Should(gomega.And(gomega.Equal(uint64(5)), gomega.Not(gomega.Equal(int32(6)))))                                   // want `ginkgo-linter: use Equal with different types: Comparing int with uint64; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)` `ginkgo-linter: use Equal with different types: Comparing int with int32; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		gomega.Expect(a).Should(gomega.Or(gomega.Equal(uint64(5)), gomega.Not(gomega.Equal(int32(6))), gomega.Not(gomega.Equal(int8(4))))) // want `ginkgo-linter: use Equal with different types: Comparing int with uint64; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)` `ginkgo-linter: use Equal with different types: Comparing int with int32; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)` `ginkgo-linter: use Equal with different types: Comparing int with int8; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		gomega.Expect(a).Should(gomega.WithTransform(func(i int) int { return i + 1 }, gomega.Equal(uint(6))))                             // want `ginkgo-linter: use Equal with different types: Comparing int with uint; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+	})
+})

--- a/testdata/src/a/comparetypes/comparetypes_test.go
+++ b/testdata/src/a/comparetypes/comparetypes_test.go
@@ -1,0 +1,57 @@
+package comparetypes_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("compare different types", func() {
+	It("find false positive check", func() {
+		a := 5
+		Expect(multi()).ShouldNot(Equal(4)) // want `ginkgo-linter: use Equal with different types: Comparing int64 with int; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		Expect(a).ShouldNot(Equal(5))
+		Expect(a).ShouldNot(Equal(uint(5)))           // want `ginkgo-linter: use Equal with different types: Comparing int with uint; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		Expect(fint64()).ShouldNot(Equal(uint64(5)))  // want `ginkgo-linter: use Equal with different types: Comparing int64 with uint64; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		Expect(fmytype()).ShouldNot(Equal(uint64(5))) // want `ginkgo-linter: use Equal with different types: Comparing a/comparetypes_test.mytype with uint64; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		Expect(a).ShouldNot(Equal(int32(5)))          // want `ginkgo-linter: use Equal with different types: Comparing int with int32; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		Expect(a).ShouldNot(Equal(uint8(5)))          // want `ginkgo-linter: use Equal with different types: Comparing int with uint8; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		Expect(a).ShouldNot(Equal(mytype(5)))         // want `ginkgo-linter: use Equal with different types: Comparing int with a/comparetypes_test.mytype; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		Expect(5).ShouldNot(Equal(mytype(5)))         // want `ginkgo-linter: use Equal with different types: Comparing int with a/comparetypes_test.mytype; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+
+		b := int16(5)
+		Expect(a).ShouldNot(Equal(b)) // want `ginkgo-linter: use Equal with different types: Comparing int with int16; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+
+		c := mytype(5)
+		Expect(a).ShouldNot(Equal(c)) // want `ginkgo-linter: use Equal with different types: Comparing int with a/comparetypes_test.mytype; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+	})
+
+	It("compare interfaces", func() {
+		var (
+			a myinf = imp1(3)
+			b myinf = imp2(3)
+		)
+		Expect(a).ShouldNot(Equal(b)) // this is not good, but not an error. Should have kind of warning here.
+		Expect(a).ShouldNot(BeEquivalentTo(b))
+		Expect(a).ShouldNot(BeIdenticalTo(b)) // this is not good, but not an error. Should have kind of warning here.
+	})
+
+	It("check HaveValue(Equal)", func() {
+		a := 5
+		pa := &a
+
+		Expect(pa).Should(HaveValue(Equal(uint64(5))))                                    // want `ginkgo-linter: use Equal with different types: Comparing int with uint64; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		Expect(a).Should(Not(Equal(uint64(5))))                                           // want `ginkgo-linter: use Equal with different types: Comparing int with uint64; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		Expect(a).Should(And(Equal(uint64(5)), Not(Equal(int32(6)))))                     // want `ginkgo-linter: use Equal with different types: Comparing int with uint64; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)` `ginkgo-linter: use Equal with different types: Comparing int with int32; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		Expect(a).Should(Or(Equal(uint64(5)), Not(Equal(int32(6))), Not(Equal(int8(4))))) // want `ginkgo-linter: use Equal with different types: Comparing int with uint64; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)` `ginkgo-linter: use Equal with different types: Comparing int with int32; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)` `ginkgo-linter: use Equal with different types: Comparing int with int8; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		Expect(a).Should(WithTransform(func(i int) int { return i + 1 }, Equal(uint(6)))) // want `ginkgo-linter: use Equal with different types: Comparing int with uint; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+	})
+
+	It("compare interface with implementations", func() {
+		var (
+			a myinf = imp1(3)
+			b       = imp1(3)
+		)
+		Expect(a).Should(Equal(b))
+		Expect(b).Should(Equal(a))
+	})
+})

--- a/testdata/src/a/comparetypesconfig/comparetypes.gomega_test.go
+++ b/testdata/src/a/comparetypesconfig/comparetypes.gomega_test.go
@@ -1,0 +1,79 @@
+package comparetypes_test
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+func fint64() int64 {
+	return 5
+}
+
+type mytype int
+
+func fmytype() mytype {
+	return 5
+}
+
+func multi() (int64, error) {
+	return 4, nil
+}
+
+type myinf interface {
+	doSomething()
+}
+
+type imp1 int
+
+func (imp1) doSomething() {
+	fmt.Println("doing something")
+}
+
+type imp2 int
+
+func (imp2) doSomething() {
+	fmt.Println("doing something else")
+}
+
+var _ = Describe("compare different types", func() {
+	It("find false positive check", func() {
+		a := 5
+		gomega.Expect(multi()).ShouldNot(gomega.Equal(4))
+		gomega.Expect(a).ShouldNot(gomega.Equal(5))
+		gomega.Expect(a).ShouldNot(gomega.Equal(uint(5)))
+		gomega.Expect(fint64()).ShouldNot(gomega.Equal(uint64(5)))
+		gomega.Expect(fmytype()).ShouldNot(gomega.Equal(uint64(5)))
+		gomega.Expect(a).ShouldNot(gomega.Equal(int32(5)))
+		gomega.Expect(a).ShouldNot(gomega.Equal(uint8(5)))
+		gomega.Expect(a).ShouldNot(gomega.Equal(mytype(5)))
+		gomega.Expect(5).ShouldNot(gomega.Equal(mytype(5)))
+
+		b := int16(5)
+		gomega.Expect(a).ShouldNot(gomega.Equal(b))
+
+		c := mytype(5)
+		gomega.Expect(a).ShouldNot(gomega.Equal(c))
+	})
+
+	It("compare interfaces", func() {
+		var (
+			a myinf = imp1(3)
+			b myinf = imp2(3)
+		)
+		gomega.Expect(a).ShouldNot(gomega.Equal(b))
+		gomega.Expect(a).ShouldNot(gomega.BeEquivalentTo(b))
+		gomega.Expect(a).ShouldNot(gomega.BeIdenticalTo(b))
+	})
+
+	It("check HaveValue(Equal)", func() {
+		a := 5
+		pa := &a
+
+		gomega.Expect(pa).Should(gomega.HaveValue(gomega.Equal(uint64(5))))
+		gomega.Expect(a).Should(gomega.Not(gomega.Equal(uint64(5))))
+		gomega.Expect(a).Should(gomega.And(gomega.Equal(uint64(5)), gomega.Not(gomega.Equal(int32(6)))))
+		gomega.Expect(a).Should(gomega.Or(gomega.Equal(uint64(5)), gomega.Not(gomega.Equal(int32(6))), gomega.Not(gomega.Equal(int8(4)))))
+		gomega.Expect(a).Should(gomega.WithTransform(func(i int) int { return i + 1 }, gomega.Equal(uint(6))))
+	})
+})

--- a/testdata/src/a/comparetypesconfig/comparetypes_test.go
+++ b/testdata/src/a/comparetypesconfig/comparetypes_test.go
@@ -1,0 +1,48 @@
+package comparetypes_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("compare different types", func() {
+	It("find false positive check", func() {
+		a := 5
+		Expect(multi()).ShouldNot(Equal(4))
+		Expect(a).ShouldNot(Equal(5))
+		Expect(a).ShouldNot(Equal(uint(5)))
+		Expect(fint64()).ShouldNot(Equal(uint64(5)))
+		Expect(fmytype()).ShouldNot(Equal(uint64(5)))
+		Expect(a).ShouldNot(Equal(int32(5)))
+		Expect(a).ShouldNot(Equal(uint8(5)))
+		Expect(a).ShouldNot(Equal(mytype(5)))
+		Expect(5).ShouldNot(Equal(mytype(5)))
+
+		b := int16(5)
+		Expect(a).ShouldNot(Equal(b))
+
+		c := mytype(5)
+		Expect(a).ShouldNot(Equal(c))
+	})
+
+	It("compare interfaces", func() {
+		var (
+			a myinf = imp1(3)
+			b myinf = imp2(3)
+		)
+		Expect(a).ShouldNot(Equal(b))
+		Expect(a).ShouldNot(BeEquivalentTo(b))
+		Expect(a).ShouldNot(BeIdenticalTo(b))
+	})
+
+	It("check HaveValue(Equal)", func() {
+		a := 5
+		pa := &a
+
+		Expect(pa).Should(HaveValue(Equal(uint64(5))))
+		Expect(a).Should(Not(Equal(uint64(5))))
+		Expect(a).Should(And(Equal(uint64(5)), Not(Equal(int32(6)))))
+		Expect(a).Should(Or(Equal(uint64(5)), Not(Equal(int32(6))), Not(Equal(int8(4)))))
+		Expect(a).Should(WithTransform(func(i int) int { return i + 1 }, Equal(uint(6))))
+	})
+})

--- a/testdata/src/a/pointerval/pointerval.go
+++ b/testdata/src/a/pointerval/pointerval.go
@@ -86,7 +86,7 @@ var _ = Describe("", Label("pointers1"), func() {
 			Expect(s3.field).Should(HaveValue(Equal(c))) // valid
 			Expect(s3.field).Should(Equal(c))            // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(s3\.field\)\.Should\(HaveValue\(Equal\(c\)\)\). instead`
 			Expect(s3.field).Should(BeIdenticalTo(p))
-			Expect(s3.field).ShouldNot(BeIdenticalTo(retStringer()))
+			Expect(s3.field).ShouldNot(BeIdenticalTo(retStringer())) // want `ginkgo-linter: use BeIdenticalTo with different types: Comparing \*string with fmt.Stringer; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of BeIdenticalTo\(\)`
 		})
 		It("pointer struct with pointer field", func() {
 			Expect(*s4.field).Should(Equal(c))           // valid
@@ -101,16 +101,16 @@ var _ = Describe("", Label("pointers1"), func() {
 		s2 := &strIfs{field: &sv}
 
 		It("struct with pointer field", func() {
-			Expect(s1.field).Should(HaveValue(Equal(c))) // valid
-			Expect(s1.field).Should(Equal(c))            // kind of valid. For interfaces, we can't tell for sure if they are pointers or not
-			Expect(s1.field).Should(BeIdenticalTo(sv))   // kind of valid. For interfaces, we can't tell for sure if they are pointers or not
+			Expect(s1.field).Should(HaveValue(Equal(c))) // want `ginkgo-linter: use Equal with different types: Comparing fmt.Stringer with string; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+			Expect(s1.field).Should(Equal(c))            // want `ginkgo-linter: use Equal with different types: Comparing fmt.Stringer with string; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+			Expect(s1.field).Should(BeIdenticalTo(sv))   // want `ginkgo-linter: use BeIdenticalTo with different types: Comparing fmt.Stringer with a/pointerval.str; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of BeIdenticalTo\(\)`
 		})
 		It("pointer struct with pointer field", func() {
-			Expect(s2.field).Should(HaveValue(Equal(c))) // valid
-			Expect(s2.field).Should(Equal(c))            // kind of valid. For interfaces, we can't tell for sure if they are pointers or not
+			Expect(s2.field).Should(HaveValue(Equal(c))) // want `ginkgo-linter: use Equal with different types: Comparing fmt.Stringer with string; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+			Expect(s2.field).Should(Equal(c))            // want `ginkgo-linter: use Equal with different types: Comparing fmt.Stringer with string; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
 		})
 		It("compare to interface", func() {
-			Expect(&sv).Should(Equal(retStringer())) // kind of valid. For interfaces, we can't tell for sure if they are pointers or not
+			Expect(&sv).Should(Equal(retStringer()))
 		})
 	})
 
@@ -164,9 +164,9 @@ var _ = Describe("", Label("pointers1"), func() {
 			Expect(px1).ShouldNot(BeEquivalentTo(nil)) // valid
 		})
 		It("BeIdenticalTo", func() {
-			Expect(px1).ShouldNot(BeIdenticalTo(5))   // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(px1\)\.ShouldNot\(HaveValue\(BeIdenticalTo\(5\)\)\). instead`
-			Expect(px1).ShouldNot(BeIdenticalTo(px2)) // valid
-			Expect(px1).ShouldNot(BeIdenticalTo(nil))
+			Expect(px1).ShouldNot(BeIdenticalTo(5))       // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(px1\)\.ShouldNot\(HaveValue\(BeIdenticalTo\(5\)\)\). instead`
+			Expect(px1).ShouldNot(BeIdenticalTo(px2))     // valid
+			Expect(px1).ShouldNot(BeIdenticalTo(nil))     // want `ginkgo-linter: use BeIdenticalTo with different types: Comparing \*float64 with untyped nil; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of BeIdenticalTo\(\)`
 			Expect(px1).Should(BeIdenticalTo(float64(5))) // want `ginkgo-linter: comparing a pointer to a value will always fail. consider using .Expect\(px1\)\.Should\(HaveValue\(BeIdenticalTo\(float64\(5\)\)\)\). instead`
 		})
 		It("", func() {

--- a/testdata/src/a/suppress/f.go
+++ b/testdata/src/a/suppress/f.go
@@ -23,8 +23,8 @@ var _ = Describe("suppress file", func() {
 		c := &b
 
 		// ginkgo-linter:ignore-nil-assert-warning
-		Expect(a).To(Equal(nil))
+		Expect(a).To(Equal(nil)) // want `ginkgo-linter: use Equal with different types: Comparing \*int with untyped nil; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
 		// ginkgo-linter:ignore-nil-assert-warning
-		Expect(c).To(Not(Equal(nil)))
+		Expect(c).To(Not(Equal(nil))) // want `ginkgo-linter: use Equal with different types: Comparing \*int with untyped nil; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
 	})
 })

--- a/testdata/src/a/suppress/typecompare_all.go
+++ b/testdata/src/a/suppress/typecompare_all.go
@@ -1,0 +1,17 @@
+package suppress
+
+// ginkgo-linter:ignore-type-compare-warning
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("suppress file", func() {
+	x := 5
+	px := &x
+	It("should ignore type compare warning", func() {
+		Expect(x).Should(Equal(uint(5)))
+		Expect(px).Should(HaveValue(Equal(uint(5))))
+	})
+})

--- a/testdata/src/a/suppress/typecompare_comment.go
+++ b/testdata/src/a/suppress/typecompare_comment.go
@@ -1,0 +1,16 @@
+package suppress
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("suppress file", func() {
+	x := 5
+	px := &x
+	It("should ignore type compare warning", func() {
+		// ginkgo-linter:ignore-type-compare-warning
+		Expect(x).Should(Equal(uint(5)))
+		Expect(px).Should(HaveValue(Equal(uint(5)))) // want `ginkgo-linter: use Equal with different types: Comparing int with uint; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+	})
+})

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -6,20 +6,22 @@ cp ginkgolinter testdata/src/a
 cd testdata/src/a
 
 # no suppress
-[[ $(./ginkgolinter a/... 2>&1 | wc -l) == 2380 ]]
+[[ $(./ginkgolinter a/... 2>&1 | wc -l) == 2462 ]]
 # suppress all but nil
-[[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 1452 ]]
+[[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1452 ]]
 # suppress all but len
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 750 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 750 ]]
 # suppress all but err
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 212 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 212 ]]
 # suppress all but compare
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-async-assertion=true a/... 2>&1 | wc -l) == 222 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 222 ]]
 # suppress all but async
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true a/... 2>&1 | wc -l) == 119 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 119 ]]
 # suppress all but focus
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-focus-container=true a/... 2>&1 | wc -l) == 143 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-focus-container=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 143 ]]
+# suppress all but compare different types
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-compare-assertion=true a/... 2>&1 | wc -l) == 209 ]]
 # allow HaveLen(0)
-[[ $(./ginkgolinter --allow-havelen-0=true a/... 2>&1 | wc -l) == 2367 ]]
+[[ $(./ginkgolinter --allow-havelen-0=true a/... 2>&1 | wc -l) == 2449 ]]
 # suppress all - should only return the few non-suppressble
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-focus-container=false a/... 2>&1 | wc -l) == 88 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-focus-container=false --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 88 ]]

--- a/types/config.go
+++ b/types/config.go
@@ -14,16 +14,18 @@ const (
 	suppressCompareAssertionWarning = suppressPrefix + "ignore-compare-assert-warning"
 	suppressAsyncAsertWarning       = suppressPrefix + "ignore-async-assert-warning"
 	suppressFocusContainerWarning   = suppressPrefix + "ignore-focus-container-warning"
+	suppressTypeCompareWarning      = suppressPrefix + "ignore-type-compare-warning"
 )
 
 type Config struct {
-	SuppressLen     Boolean
-	SuppressNil     Boolean
-	SuppressErr     Boolean
-	SuppressCompare Boolean
-	SuppressAsync   Boolean
-	ForbidFocus     Boolean
-	AllowHaveLen0   Boolean
+	SuppressLen         Boolean
+	SuppressNil         Boolean
+	SuppressErr         Boolean
+	SuppressCompare     Boolean
+	SuppressAsync       Boolean
+	ForbidFocus         Boolean
+	SuppressTypeCompare Boolean
+	AllowHaveLen0       Boolean
 }
 
 func (s *Config) AllTrue() bool {
@@ -32,13 +34,14 @@ func (s *Config) AllTrue() bool {
 
 func (s *Config) Clone() Config {
 	return Config{
-		SuppressLen:     s.SuppressLen,
-		SuppressNil:     s.SuppressNil,
-		SuppressErr:     s.SuppressErr,
-		SuppressCompare: s.SuppressCompare,
-		SuppressAsync:   s.SuppressAsync,
-		ForbidFocus:     s.ForbidFocus,
-		AllowHaveLen0:   s.AllowHaveLen0,
+		SuppressLen:         s.SuppressLen,
+		SuppressNil:         s.SuppressNil,
+		SuppressErr:         s.SuppressErr,
+		SuppressCompare:     s.SuppressCompare,
+		SuppressAsync:       s.SuppressAsync,
+		ForbidFocus:         s.ForbidFocus,
+		SuppressTypeCompare: s.SuppressTypeCompare,
+		AllowHaveLen0:       s.AllowHaveLen0,
 	}
 }
 
@@ -69,6 +72,8 @@ func (s *Config) UpdateFromComment(commentGroup []*ast.CommentGroup) {
 					s.SuppressAsync = true
 				case suppressFocusContainerWarning:
 					s.ForbidFocus = false
+				case suppressTypeCompareWarning:
+					s.SuppressTypeCompare = true
 				}
 			}
 		}


### PR DESCRIPTION
The `Equal` and the `BeIdentical` matchers also check the type, not only the value.

The following code will fail in runtime:
```go
x := 5 // x is int
Expect(x).Should(Eqaul(uint(5)) // x and uint(5) are with different
types
```

When using negative checks, it's even worse, because we get a fale positive:
```
x := 5
Expect(x).ToNot(Equal(uint(5))
```

To solve this problem, we want to find these errors before running the tests and failing on runtime. This is even more important for e2e or functional tests, where we sometimes can't run them on the local development environment.

This PR adds a new rule to the linter, to find comaprison of values from different types.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added test case and related test data
- [x] Update the functional test

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)

@pohly

fixes #109 
