### PR TITLE
Fix the compare different type rule, to allow using WithTransform

### DIFF
--- a/testdata/src/a/comparetypes/comparetypes_test.go
+++ b/testdata/src/a/comparetypes/comparetypes_test.go
@@ -5,6 +5,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+func uint2int(u uint) int {
+	return int(u)
+}
+
 var _ = Describe("compare different types", func() {
 	It("find false positive check", func() {
 		a := 5
@@ -53,5 +57,15 @@ var _ = Describe("compare different types", func() {
 		)
 		Expect(a).Should(Equal(b))
 		Expect(b).Should(Equal(a))
+	})
+
+	It("test WithTransform", func() {
+		a := uint(5)
+		Expect(uint(5)).Should(WithTransform(func(i uint) int { return int(i) }, Equal(5)))
+		Expect(uint(5)).Should(WithTransform(func(i uint) uint64 { return uint64(i) }, Equal(5))) // want `ginkgo-linter: use Equal with different types: Comparing uint64 with int; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		Expect(a).Should(WithTransform(func(i uint) int { return int(i) }, Equal(5)))
+		Expect(a).Should(WithTransform(uint2int, Equal(5)))
+		Expect(a).Should(WithTransform(uint2int, Equal(uint64(5)))) // want `ginkgo-linter: use Equal with different types: Comparing int with uint64; either change the expected value type if possible, or use the BeEquivalentTo\(\) matcher, instead of Equal\(\)`
+		Expect(5).Should(WithTransform(func(i int) myinf { return imp1(i) }, Equal(imp1(5))))
 	})
 })

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -6,7 +6,7 @@ cp ginkgolinter testdata/src/a
 cd testdata/src/a
 
 # no suppress
-[[ $(./ginkgolinter a/... 2>&1 | wc -l) == 2462 ]]
+[[ $(./ginkgolinter a/... 2>&1 | wc -l) == 2464 ]]
 # suppress all but nil
 [[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1452 ]]
 # suppress all but len
@@ -20,8 +20,8 @@ cd testdata/src/a
 # suppress all but focus
 [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-focus-container=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 143 ]]
 # suppress all but compare different types
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-compare-assertion=true a/... 2>&1 | wc -l) == 209 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-compare-assertion=true a/... 2>&1 | wc -l) == 211 ]]
 # allow HaveLen(0)
-[[ $(./ginkgolinter --allow-havelen-0=true a/... 2>&1 | wc -l) == 2449 ]]
+[[ $(./ginkgolinter --allow-havelen-0=true a/... 2>&1 | wc -l) == 2451 ]]
 # suppress all - should only return the few non-suppressble
 [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-focus-container=false --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 88 ]]


### PR DESCRIPTION
# Description

The `WithTransform` matcher can be used to transform the actual value type. This PR fix a false positive when using this matcher to change the actual value type to match the matcher type.

For example:
```go
Expect(uint(5)).Should(WithTransform(func(i uint) int { return int(i) }, Equal(5)))
```

In this case, the test should work because the transform function (the first parameter of the `WithTransform` matcher) casts the `uint` actual value to `int`, to match the `Equal(5)` matcher.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added test case and related test data
- [x] Update the functional test

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)

@nunnatsa
