### PR TITLE
downgrade to go1.20 because golangci-lint does not support go1.21, yet

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -14,14 +14,14 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: '1.20'
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.54.1
+        version: v1.55.2
         skip-go-installation: true
         skip-pkg-cache: true
         args: --timeout=5m

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nunnatsa/ginkgolinter
 
-go 1.21
+go 1.20
 
 require (
 	github.com/go-toolsmith/astcopy v1.1.0


### PR DESCRIPTION
# Description

Downgrade to go1.20 because golangci-lint does not support go1.21, yet

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added test case and related test data
- [ ] Update the functional test

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I ran [golangci-lint](https://github.com/golangci/golangci-lint)

@nunnatsa
