### PR TITLE
Add new optional rule: force `Expect` with `To`

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,17 @@ Expect(x1 == c1).Should(BeTrue()) // ==> Expect(x1).Should(Equal(c1))
 Expect(c1 == x1).Should(BeTrue()) // ==> Expect(x1).Should(Equal(c1))
 ```
 
+### Don't Allow Using `Expect` with `Should` or `ShouldNot` [STYLE]
+This optional rule forces the usage of the `Expect` method only with the `To`, `ToNot` or `NotTo` 
+assertion methods; e.g.
+```go
+Expect("abc").Should(HaveLen(3)) // => Expect("abc").To(HaveLen(3))
+Expect("abc").ShouldNot(BeEmpty()) // => Expect("abc").ToNot(BeEmpty())
+```
+This rule support auto fixing.
+
+***This rule is disabled by default***. Use the `--force-expect-to=true` command line flag to enable it.
+
 ## Suppress the linter
 ### Suppress warning from command line
 * Use the `--suppress-len-assertion=true` flag to suppress the wrong length assertion warning

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,54 @@
+package ginkgolinter
+
+const doc = `enforces standards of using ginkgo and gomega
+
+or
+       ginkgolinter version
+
+version: %s
+
+currently, the linter searches for following:
+* trigger a warning when using Eventually or Constantly with a function call. This is in order to prevent the case when 
+  using a function call instead of a function. Function call returns a value only once, and so the original value
+  is tested again and again and is never changed. [Bug]
+
+* trigger a warning when comparing a pointer to a value. [Bug]
+
+* trigger a warning for missing assertion method: [Bug]
+	Eventually(checkSomething)
+
+* trigger a warning when a ginkgo focus container (FDescribe, FContext, FWhen or FIt) is found. [Bug]
+
+* validate the MatchError gomega matcher [Bug]
+
+* trigger a warning when using the Equal or the BeIdentical matcher with two different types, as these matchers will
+  fail in runtime.
+
+* wrong length assertions. We want to assert the item rather than its length. [Style]
+For example:
+	Expect(len(x)).Should(Equal(1))
+This should be replaced with:
+	Expect(x)).Should(HavelLen(1))
+	
+* wrong nil assertions. We want to assert the item rather than a comparison result. [Style]
+For example:
+	Expect(x == nil).Should(BeTrue())
+This should be replaced with:
+	Expect(x).Should(BeNil())
+
+* wrong error assertions. For example: [Style]
+	Expect(err == nil).Should(BeTrue())
+This should be replaced with:
+	Expect(err).ShouldNot(HaveOccurred())
+
+* wrong boolean comparison, for example: [Style]
+	Expect(x == 8).Should(BeTrue())
+This should be replaced with:
+	Expect(x).Should(BeEqual(8))
+
+* replaces Equal(true/false) with BeTrue()/BeFalse() [Style]
+
+* replaces HaveLen(0) with BeEmpty() [Style]
+
+* replaces Expect(...).Should(...) with Expect(...).To() [stype]
+`

--- a/ginkgo_linter_test.go
+++ b/ginkgo_linter_test.go
@@ -142,6 +142,11 @@ func TestFlags(t *testing.T) {
 			testData: []string{"a/comparetypesconfig"},
 			flags:    map[string]string{"suppress-type-compare-assertion": "true"},
 		},
+		{
+			testName: "test the force-expect-to flag",
+			testData: []string{"a/forceExpectTo"},
+			flags:    map[string]string{"force-expect-to": "true"},
+		},
 	} {
 		t.Run(tc.testName, func(tt *testing.T) {
 			analyzer := ginkgolinter.NewAnalyzer()

--- a/gomegahandler/handler.go
+++ b/gomegahandler/handler.go
@@ -70,7 +70,12 @@ func (h dotHandler) GetActualFuncName(expr *ast.CallExpr) (string, bool) {
 
 // ReplaceFunction replaces the function with another one, for fix suggestions
 func (dotHandler) ReplaceFunction(caller *ast.CallExpr, newExpr *ast.Ident) {
-	caller.Fun = newExpr
+	switch f := caller.Fun.(type) {
+	case *ast.Ident:
+		caller.Fun = newExpr
+	case *ast.SelectorExpr:
+		f.Sel = newExpr
+	}
 }
 
 func (dotHandler) getDefFuncName(expr *ast.CallExpr) string {

--- a/testdata/src/a/forceExpectTo/gomegavar.go
+++ b/testdata/src/a/forceExpectTo/gomegavar.go
@@ -1,0 +1,22 @@
+package forceExpectTo
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("gomega var", func() {
+	It("in a valid Eventually", func() {
+		Eventually(func(g Gomega) {
+			g.Expect("a").Should(HaveLen(1))    // want `ginkgo-linter: must not use Expect with Should; consider using .g\.Expect\("a"\)\.To\(HaveLen\(1\)\). instead`
+			g.Expect(len("a")).Should(Equal(1)) // want `ginkgo-linter: wrong length assertion; consider using .g\.Expect\("a"\)\.Should\(HaveLen\(1\)\). instead` `ginkgo-linter: must not use Expect with Should; consider using .g\.Expect\("a"\)\.To\(HaveLen\(1\)\). instead`
+		}).Should(Succeed())
+	})
+
+	It("in an invalid Eventually", func() {
+		Eventually(func(g Gomega) { // want `ginkgo-linter: "Eventually": missing assertion method\. Expected "Should\(\)" or "ShouldNot\(\)"`
+			g.Expect("a").Should(HaveLen(1))    // want `ginkgo-linter: must not use Expect with Should; consider using .g\.Expect\("a"\)\.To\(HaveLen\(1\)\). instead`
+			g.Expect(len("a")).Should(Equal(1)) // want `ginkgo-linter: wrong length assertion; consider using .g\.Expect\("a"\)\.Should\(HaveLen\(1\)\). instead` `ginkgo-linter: must not use Expect with Should; consider using .g\.Expect\("a"\)\.To\(HaveLen\(1\)\). instead`
+		})
+	})
+})

--- a/testdata/src/a/forceExpectTo/nodotimport.go
+++ b/testdata/src/a/forceExpectTo/nodotimport.go
@@ -1,0 +1,19 @@
+package forceExpectTo
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = Describe("simple case", func() {
+	It("just replace assertion method", func() {
+		gomega.Expect("a").Should(gomega.HaveLen(1))            // want `ginkgo-linter: must not use Expect with Should; consider using .gomega\.Expect\("a"\)\.To\(gomega\.HaveLen\(1\)\). instead`
+		gomega.Expect("a").ShouldNot(gomega.BeEmpty())          // want `ginkgo-linter: must not use Expect with ShouldNot; consider using .gomega\.Expect\("a"\)\.ToNot\(gomega\.BeEmpty\(\)\). instead`
+		gomega.Expect("a").Should(gomega.Not(gomega.BeEmpty())) // want `ginkgo-linter: must not use Expect with ShouldNot; consider using .gomega\.Expect\("a"\)\.ToNot\(gomega\.BeEmpty\(\)\). instead`
+	})
+
+	It("mix with len assertion", func() {
+		gomega.Expect(len("a")).Should(gomega.Equal(1))    // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("a"\)\.Should\(gomega\.HaveLen\(1\)\). instead` `ginkgo-linter: must not use Expect with Should; consider using .gomega\.Expect\("a"\)\.To\(gomega\.HaveLen\(1\)\). instead`
+		gomega.Expect(len("a")).ShouldNot(gomega.Equal(0)) // want `ginkgo-linter: wrong length assertion; consider using .gomega\.Expect\("a"\)\.ShouldNot\(gomega\.BeEmpty\(\)\). instead` `ginkgo-linter: must not use Expect with ShouldNot; consider using .gomega\.Expect\("a"\)\.ToNot\(gomega\.BeEmpty\(\)\). instead`
+	})
+})

--- a/testdata/src/a/forceExpectTo/simple.go
+++ b/testdata/src/a/forceExpectTo/simple.go
@@ -1,0 +1,21 @@
+package forceExpectTo
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("simple case", func() {
+	It("just replace assertion method", func() {
+		Expect("a").Should(HaveLen(1))     // want `ginkgo-linter: must not use Expect with Should; consider using .Expect\("a"\)\.To\(HaveLen\(1\)\). instead`
+		Expect("a").ShouldNot(BeEmpty())   // want `ginkgo-linter: must not use Expect with ShouldNot; consider using .Expect\("a"\)\.ToNot\(BeEmpty\(\)\). instead`
+		Expect("a").Should(Not(BeEmpty())) // want `ginkgo-linter: must not use Expect with ShouldNot; consider using .Expect\("a"\)\.ToNot\(BeEmpty\(\)\). instead`
+		Ω("a").Should(HaveLen(1))
+		Ω("a").ShouldNot(BeEmpty())
+	})
+
+	It("mix with len assertion", func() {
+		Expect(len("a")).Should(Equal(1))    // want `ginkgo-linter: wrong length assertion; consider using .Expect\("a"\)\.Should\(HaveLen\(1\)\). instead` `ginkgo-linter: must not use Expect with Should; consider using .Expect\("a"\)\.To\(HaveLen\(1\)\). instead`
+		Expect(len("a")).ShouldNot(Equal(0)) // want `ginkgo-linter: wrong length assertion; consider using .Expect\("a"\)\.ShouldNot\(BeEmpty\(\)\). instead` `ginkgo-linter: must not use Expect with ShouldNot; consider using .Expect\("a"\)\.ToNot\(BeEmpty\(\)\). instead`
+	})
+})

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -6,22 +6,26 @@ cp ginkgolinter testdata/src/a
 cd testdata/src/a
 
 # no suppress
-[[ $(./ginkgolinter a/... 2>&1 | wc -l) == 2540 ]]
+[[ $(./ginkgolinter a/... 2>&1 | wc -l) == 2547 ]]
 # suppress all but nil
-[[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1518 ]]
+[[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1519 ]]
 # suppress all but len
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 816 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 823 ]]
 # suppress all but err
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 278 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 279 ]]
 # suppress all but compare
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 288 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 289 ]]
 # suppress all but async
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 191 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 192 ]]
 # suppress all but focus
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-focus-container=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 209 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-focus-container=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 210 ]]
 # suppress all but compare different types
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-compare-assertion=true a/... 2>&1 | wc -l) == 287 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-compare-assertion=true a/... 2>&1 | wc -l) == 288 ]]
 # allow HaveLen(0)
-[[ $(./ginkgolinter --allow-havelen-0=true a/... 2>&1 | wc -l) == 2526 ]]
+[[ $(./ginkgolinter --allow-havelen-0=true a/... 2>&1 | wc -l) == 2533 ]]
+# force Expect with To
+[[ $(./ginkgolinter --force-expect-to=true a/... 2>&1 | wc -l) == 3209 ]]
 # suppress all - should only return the few non-suppressble
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-focus-container=false --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 154 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-focus-container=false --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 155 ]]
+# suppress all, force  Expect with To
+[[ $(./ginkgolinter --force-expect-to=true --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-focus-container=false --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 817 ]]

--- a/types/config.go
+++ b/types/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	ForbidFocus         Boolean
 	SuppressTypeCompare Boolean
 	AllowHaveLen0       Boolean
+	ForceExpectTo       Boolean
 }
 
 func (s *Config) AllTrue() bool {
@@ -42,6 +43,7 @@ func (s *Config) Clone() Config {
 		ForbidFocus:         s.ForbidFocus,
 		SuppressTypeCompare: s.SuppressTypeCompare,
 		AllowHaveLen0:       s.AllowHaveLen0,
+		ForceExpectTo:       s.ForceExpectTo,
 	}
 }
 


### PR DESCRIPTION
# Description
Added new rule: should not use `Expect` with the `Should` or `ShouldNot` assertion methods.

This rule is not enabled by default. To enable it, use the `--force-expect-to=true` flag.

The new rule does support auto fix.

Fixes #112 

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
- [x] Added test case and related test data
- [x] Update the functional test

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)

@nunnatsa
