### PR TITLE
New Rule: cap assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,20 @@ The output of the linter,when finding issues, looks like this:
 ./testdata/src/a/a.go:18:5: ginkgo-linter: wrong length assertion; consider using `Expect("").Should(BeEmpty())` instead
 ./testdata/src/a/a.go:22:5: ginkgo-linter: wrong length assertion; consider using `Expect("").Should(BeEmpty())` instead
 ```
+
+### Wrong Cap Assertion [STYLE]
+The linter finds assertion of the golang built-in `cap` function, with all kind of matchers, while there are already
+gomega matchers for these usecases; We want to assert the item, rather than its cap.
+
+There are several wrong patterns:
+```go
+Expect(cap(x)).To(Equal(0)) // should be: Expect(x).To(HaveCap(0))
+Expect(cap(x)).To(BeZero()) // should be: Expect(x).To(HaveCap(0))
+Expect(cap(x)).To(BeNumeric(">", 0)) // should be: Expect(x).ToNot(HaveCap(0))
+Expect(cap(x)).To(BeNumeric("==", 2)) // should be: Expect(x).To(HaveCap(2))
+Expect(cap(x)).To(BeNumeric("!=", 3)) // should be: Expect(x).ToNot(HaveCap(3))
+```
+
 #### use the `HaveLen(0)` matcher.  [STYLE]
 The linter will also warn about the `HaveLen(0)` matcher, and will suggest to replace it with `BeEmpty()`
 
@@ -369,7 +383,7 @@ This rule support auto fixing.
 
 ## Suppress the linter
 ### Suppress warning from command line
-* Use the `--suppress-len-assertion=true` flag to suppress the wrong length assertion warning
+* Use the `--suppress-len-assertion=true` flag to suppress the wrong length and cap assertions warning
 * Use the `--suppress-nil-assertion=true` flag to suppress the wrong nil assertion warning
 * Use the `--suppress-err-assertion=true` flag to suppress the wrong error assertion warning
 * Use the `--suppress-compare-assertion=true` flag to suppress the wrong comparison assertion warning
@@ -380,7 +394,7 @@ This rule support auto fixing.
   command line, and not from a comment.
 
 ### Suppress warning from the code
-To suppress the wrong length assertion warning, add a comment with (only)
+To suppress the wrong length and cap assertions warning, add a comment with (only)
 
 `ginkgo-linter:ignore-len-assert-warning`. 
 

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -89,6 +89,10 @@ func TestAllUseCases(t *testing.T) {
 			testName: "issue 124: custom matcher form other packages",
 			testData: "a/issue-124",
 		},
+		{
+			testName: "cap",
+			testData: "a/cap",
+		},
 	} {
 		t.Run(tc.testName, func(tt *testing.T) {
 			analysistest.Run(tt, analysistest.TestData(), ginkgolinter.NewAnalyzer(), tc.testData)

--- a/doc.go
+++ b/doc.go
@@ -30,6 +30,12 @@ For example:
 This should be replaced with:
 	Expect(x)).Should(HavelLen(1))
 	
+* wrong cap assertions. We want to assert the item rather than its cap. [Style]
+For example:
+	Expect(cap(x)).Should(Equal(1))
+This should be replaced with:
+	Expect(x)).Should(HavelCap(1))
+	
 * wrong nil assertions. We want to assert the item rather than a comparison result. [Style]
 For example:
 	Expect(x == nil).Should(BeTrue())

--- a/testdata/src/a/cap/cap.ginkgo.go
+++ b/testdata/src/a/cap/cap.ginkgo.go
@@ -1,0 +1,37 @@
+package cap
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = Describe("check cap", func() {
+	It("should not allow expect cap", func() {
+		slice := make([]int, 0, 10)
+		gomega.Expect(cap(slice)).To(gomega.Equal(10))                 // want `ginkgo-linter: wrong cap assertion. Consider using .gomega\.Expect\(slice\)\.To\(gomega\.HaveCap\(10\)\). instead`
+		gomega.Expect(cap(slice)).ToNot(gomega.Equal(0))               // want `ginkgo-linter: wrong cap assertion. Consider using .gomega\.Expect\(slice\)\.ToNot\(gomega\.HaveCap\(0\)\). instead`
+		gomega.Expect(cap(slice)).ToNot(gomega.Equal(5))               // want `ginkgo-linter: wrong cap assertion. Consider using .gomega\.Expect\(slice\)\.ToNot\(gomega\.HaveCap\(5\)\). instead`
+		gomega.Expect(cap(slice)).ToNot(gomega.BeZero())               // want `ginkgo-linter: wrong cap assertion. Consider using .gomega\.Expect\(slice\)\.ToNot\(gomega\.HaveCap\(0\)\). instead`
+		gomega.Expect(cap(slice)).To(gomega.BeNumerically("==", 10))   // want `ginkgo-linter: wrong cap assertion. Consider using .gomega\.Expect\(slice\)\.To\(gomega\.HaveCap\(10\)\). instead`
+		gomega.Expect(cap(slice)).To(gomega.BeNumerically("!=", 0))    // want `ginkgo-linter: wrong cap assertion. Consider using .gomega\.Expect\(slice\)\.ToNot\(gomega\.HaveCap\(0\)\). instead`
+		gomega.Expect(cap(slice)).ToNot(gomega.BeNumerically("==", 0)) // want `ginkgo-linter: wrong cap assertion. Consider using .gomega\.Expect\(slice\)\.ToNot\(gomega\.HaveCap\(0\)\). instead`
+		gomega.Expect(cap(slice)).To(gomega.BeNumerically("!=", 5))    // want `ginkgo-linter: wrong cap assertion. Consider using .gomega\.Expect\(slice\)\.ToNot\(gomega\.HaveCap\(5\)\). instead`
+		gomega.Expect(cap(slice)).ToNot(gomega.BeNumerically("==", 5)) // want `ginkgo-linter: wrong cap assertion. Consider using .gomega\.Expect\(slice\)\.ToNot\(gomega\.HaveCap\(5\)\). instead`
+		gomega.Expect(cap(slice)).To(gomega.BeNumerically(">", 0))     // want `ginkgo-linter: wrong cap assertion. Consider using .gomega\.Expect\(slice\)\.ToNot\(gomega\.HaveCap\(0\)\). instead`
+		gomega.Expect(cap(slice)).To(gomega.BeNumerically(">=", 1))    // want `ginkgo-linter: wrong cap assertion. Consider using .gomega\.Expect\(slice\)\.ToNot\(gomega\.HaveCap\(0\)\). instead`
+		gomega.Expect(slice).To(gomega.BeEmpty())
+		gomega.Expect(slice).To(gomega.HaveCap(10))
+	})
+
+	It("should not allow comparison with cap", func() {
+		slice := make([]int, 0, 10)
+		gomega.Expect(cap(slice) == 10).To(gomega.BeTrue())        // want `ginkgo-linter: wrong cap assertion. Consider using .gomega\.Expect\(slice\)\.To\(gomega\.HaveCap\(10\)\). instead`
+		gomega.Expect(cap(slice) == 10).To(gomega.Equal(true))     // want `ginkgo-linter: wrong cap assertion. Consider using .gomega\.Expect\(slice\)\.To\(gomega\.HaveCap\(10\)\). instead`
+		gomega.Expect(cap(slice) != 10).To(gomega.BeFalse())       // want `ginkgo-linter: wrong cap assertion. Consider using .gomega\.Expect\(slice\)\.To\(gomega\.HaveCap\(10\)\). instead`
+		gomega.Expect(cap(slice) != 10).To(gomega.Equal(false))    // want `ginkgo-linter: wrong cap assertion. Consider using .gomega\.Expect\(slice\)\.To\(gomega\.HaveCap\(10\)\). instead`
+		gomega.Expect(cap(slice) == 10).ToNot(gomega.BeFalse())    // want `ginkgo-linter: wrong cap assertion. Consider using .gomega\.Expect\(slice\)\.To\(gomega\.HaveCap\(10\)\). instead`
+		gomega.Expect(cap(slice) == 10).ToNot(gomega.Equal(false)) // want `ginkgo-linter: wrong cap assertion. Consider using .gomega\.Expect\(slice\)\.To\(gomega\.HaveCap\(10\)\). instead`
+		gomega.Expect(cap(slice) != 10).ToNot(gomega.BeTrue())     // want `ginkgo-linter: wrong cap assertion. Consider using .gomega\.Expect\(slice\)\.To\(gomega\.HaveCap\(10\)\). instead`
+		gomega.Expect(cap(slice) != 10).ToNot(gomega.Equal(true))  // want `ginkgo-linter: wrong cap assertion. Consider using .gomega\.Expect\(slice\)\.To\(gomega\.HaveCap\(10\)\). instead`
+	})
+})

--- a/testdata/src/a/cap/cap.go
+++ b/testdata/src/a/cap/cap.go
@@ -1,0 +1,38 @@
+package cap
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("check cap", func() {
+	It("should not allow expect cap", func() {
+		slice := make([]int, 0, 10)
+		Expect(cap(slice)).To(Equal(10))                 // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.To\(HaveCap\(10\)\). instead`
+		Expect(cap(slice)).ToNot(Equal(0))               // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.ToNot\(HaveCap\(0\)\). instead`
+		Expect(cap(slice)).ToNot(Equal(5))               // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.ToNot\(HaveCap\(5\)\). instead`
+		Expect(cap(slice)).ToNot(BeZero())               // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.ToNot\(HaveCap\(0\)\). instead`
+		Expect(cap(slice)).To(BeNumerically("==", 10))   // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.To\(HaveCap\(10\)\). instead`
+		Expect(cap(slice)).To(BeNumerically("!=", 0))    // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.ToNot\(HaveCap\(0\)\). instead`
+		Expect(cap(slice)).ToNot(BeNumerically("==", 0)) // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.ToNot\(HaveCap\(0\)\). instead`
+		Expect(cap(slice)).To(BeNumerically("!=", 5))    // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.ToNot\(HaveCap\(5\)\). instead`
+		Expect(cap(slice)).ToNot(BeNumerically("==", 5)) // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.ToNot\(HaveCap\(5\)\). instead`
+		Expect(cap(slice)).To(BeNumerically(">", 0))     // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.ToNot\(HaveCap\(0\)\). instead`
+		Expect(cap(slice)).To(BeNumerically(">=", 1))    // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.ToNot\(HaveCap\(0\)\). instead`
+		Expect(slice).To(BeEmpty())
+		Expect(slice).To(HaveCap(10))
+	})
+
+	It("should not allow comparison with cap", func() {
+		slice := make([]int, 0, 10)
+		Expect(cap(slice) == 10).To(BeTrue())        // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.To\(HaveCap\(10\)\). instead`
+		Expect(cap(slice) == 10).To(Equal(true))     // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.To\(HaveCap\(10\)\). instead`
+		Expect(cap(slice) != 10).To(BeFalse())       // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.To\(HaveCap\(10\)\). instead`
+		Expect(cap(slice) != 10).To(Equal(false))    // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.To\(HaveCap\(10\)\). instead`
+		Expect(cap(slice) == 10).ToNot(BeFalse())    // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.To\(HaveCap\(10\)\). instead`
+		Expect(cap(slice) == 10).ToNot(Equal(false)) // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.To\(HaveCap\(10\)\). instead`
+		Expect(cap(slice) != 10).ToNot(BeTrue())     // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.To\(HaveCap\(10\)\). instead`
+		Expect(cap(slice) != 10).ToNot(Equal(true))  // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.To\(HaveCap\(10\)\). instead`
+		Expect(10 != cap(slice)).ToNot(Equal(true))  // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.To\(HaveCap\(10\)\). instead`
+	})
+})

--- a/testdata/src/a/cap/mix-with-len.go
+++ b/testdata/src/a/cap/mix-with-len.go
@@ -1,0 +1,14 @@
+package cap
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("mix len and cap", func() {
+	slice := make([]int, 0)
+	It("compare len with cap", func() {
+		Expect(cap(slice) == len(slice)).To(BeTrue()) // want `wrong cap assertion. Consider using .Expect\(slice\)\.To\(HaveCap\(len\(slice\)\)\). instead`
+		Expect(len(slice) == cap(slice)).To(BeTrue()) // want `wrong length assertion. Consider using .Expect\(slice\)\.To\(HaveLen\(cap\(slice\)\)\). instead`
+	})
+})

--- a/testdata/src/a/cap/suppress-expr.go
+++ b/testdata/src/a/cap/suppress-expr.go
@@ -1,0 +1,28 @@
+package cap
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("check cap", func() {
+	It("should not allow expect cap", func() {
+		slice := make([]int, 0, 10)
+		// ginkgo-linter:ignore-len-assert-warning
+		Expect(cap(slice)).To(Equal(10))
+		// ginkgo-linter:ignore-len-assert-warning
+		Expect(cap(slice)).ToNot(BeZero())
+		// ginkgo-linter:ignore-len-assert-warning
+		Expect(cap(slice)).To(BeNumerically("==", 10))
+		Expect(cap(slice)).To(Equal(10))               // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.To\(HaveCap\(10\)\). instead`
+		Expect(cap(slice)).ToNot(BeZero())             // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.ToNot\(HaveCap\(0\)\). instead`
+		Expect(cap(slice)).To(BeNumerically("==", 10)) // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.To\(HaveCap\(10\)\). instead`
+	})
+
+	It("should not allow comparison with cap", func() {
+		slice := make([]int, 0, 10)
+		// ginkgo-linter:ignore-len-assert-warning
+		Expect(cap(slice) == 10).To(BeTrue()) // want `wrong comparison assertion. Consider using .Expect\(cap\(slice\)\)\.To\(Equal\(10\)\). instead`
+		Expect(cap(slice) == 10).To(BeTrue()) // want `ginkgo-linter: wrong cap assertion. Consider using .Expect\(slice\)\.To\(HaveCap\(10\)\). instead`
+	})
+})

--- a/testdata/src/a/cap/suppress-file.go
+++ b/testdata/src/a/cap/suppress-file.go
@@ -1,0 +1,41 @@
+package cap
+
+// ginkgo-linter:ignore-len-assert-warning
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+// ginkgo-linter:ignore-len-assert-warning
+
+var _ = Describe("check cap", func() {
+	It("should not allow expect cap", func() {
+		slice := make([]int, 0, 10)
+		gomega.Expect(cap(slice)).To(gomega.Equal(10))
+		gomega.Expect(cap(slice)).ToNot(gomega.Equal(0))
+		gomega.Expect(cap(slice)).ToNot(gomega.Equal(5))
+		gomega.Expect(cap(slice)).ToNot(gomega.BeZero())
+		gomega.Expect(cap(slice)).To(gomega.BeNumerically("==", 10))
+		gomega.Expect(cap(slice)).To(gomega.BeNumerically("!=", 0))
+		gomega.Expect(cap(slice)).ToNot(gomega.BeNumerically("==", 0))
+		gomega.Expect(cap(slice)).To(gomega.BeNumerically("!=", 5))
+		gomega.Expect(cap(slice)).ToNot(gomega.BeNumerically("==", 5))
+		gomega.Expect(cap(slice)).To(gomega.BeNumerically(">", 0))
+		gomega.Expect(cap(slice)).To(gomega.BeNumerically(">=", 1))
+		gomega.Expect(slice).To(gomega.BeEmpty())
+		gomega.Expect(slice).To(gomega.HaveCap(10))
+	})
+
+	It("should not allow comparison with cap", func() {
+		slice := make([]int, 0, 10)
+		gomega.Expect(cap(slice) == 10).To(gomega.BeTrue())        // want `wrong comparison assertion. Consider using .gomega\.Expect\(cap\(slice\)\)\.To\(gomega\.Equal\(10\)\). instead`
+		gomega.Expect(cap(slice) == 10).To(gomega.Equal(true))     // want `wrong comparison assertion. Consider using .gomega\.Expect\(cap\(slice\)\)\.To\(gomega\.Equal\(10\)\). instead`
+		gomega.Expect(cap(slice) != 10).To(gomega.BeFalse())       // want `wrong comparison assertion. Consider using .gomega\.Expect\(cap\(slice\)\)\.To\(gomega\.Equal\(10\)\). instead`
+		gomega.Expect(cap(slice) != 10).To(gomega.Equal(false))    // want `wrong comparison assertion. Consider using .gomega\.Expect\(cap\(slice\)\)\.To\(gomega\.Equal\(10\)\). instead`
+		gomega.Expect(cap(slice) == 10).ToNot(gomega.BeFalse())    // want `wrong comparison assertion. Consider using .gomega\.Expect\(cap\(slice\)\)\.To\(gomega\.Equal\(10\)\). instead`
+		gomega.Expect(cap(slice) == 10).ToNot(gomega.Equal(false)) // want `wrong comparison assertion. Consider using .gomega\.Expect\(cap\(slice\)\)\.To\(gomega\.Equal\(10\)\). instead`
+		gomega.Expect(cap(slice) != 10).ToNot(gomega.BeTrue())     // want `wrong comparison assertion. Consider using .gomega\.Expect\(cap\(slice\)\)\.To\(gomega\.Equal\(10\)\). instead`
+		gomega.Expect(cap(slice) != 10).ToNot(gomega.Equal(true))  // want `wrong comparison assertion. Consider using .gomega\.Expect\(cap\(slice\)\)\.To\(gomega\.Equal\(10\)\). instead`
+	})
+})

--- a/testdata/src/a/configlen/a.go
+++ b/testdata/src/a/configlen/a.go
@@ -1482,4 +1482,23 @@ var _ = Describe("test data for the ginkgo-linter", func() {
 			})
 		})
 	})
+
+	Context("check cap", func() {
+		slice := make([]int, 0, 10)
+		It("check cap", func() {
+			Expect(cap(slice)).To(Equal(10))
+			Expect(cap(slice)).ToNot(BeZero())
+			Expect(cap(slice)).ToNot(Equal(5))
+			Expect(cap(slice)).To(BeNumerically("==", 10))
+			Expect(cap(slice)).ToNot(BeNumerically("!=", 10))
+			Expect(cap(slice)).To(BeNumerically(">", 0))
+			Expect(cap(slice)).To(BeNumerically(">=", 1))
+		})
+		It("check cap compare", func() {
+			Expect(cap(slice) == 10).To(BeTrue())    // want `wrong comparison assertion. Consider using .Expect\(cap\(slice\)\).To\(Equal\(10\)\). instead`
+			Expect(cap(slice) == 10).To(Equal(true)) // want `wrong comparison assertion. Consider using .Expect\(cap\(slice\)\).To\(Equal\(10\)\). instead`
+			Expect(cap(slice) != 0).To(BeFalse())    // want `wrong comparison assertion. Consider using .Expect\(cap\(slice\)\).To\(BeZero\(\)\). instead`
+			Expect(cap(slice) != 0).To(Equal(false)) // want `wrong comparison assertion. Consider using .Expect\(cap\(slice\)\).To\(BeZero\(\)\). instead`
+		})
+	})
 })

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -6,15 +6,15 @@ cp ginkgolinter testdata/src/a
 cd testdata/src/a
 
 # no suppress
-[[ $(./ginkgolinter a/... 2>&1 | wc -l) == 2526 ]]
+[[ $(./ginkgolinter a/... 2>&1 | wc -l) == 2591 ]]
 # suppress all but nil
 [[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1516 ]]
 # suppress all but len
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 820 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 876 ]]
 # suppress all but err
 [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 276 ]]
 # suppress all but compare
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 286 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 319 ]]
 # suppress all but async
 [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 183 ]]
 # suppress all but focus
@@ -22,9 +22,9 @@ cd testdata/src/a
 # suppress all but compare different types
 [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-compare-assertion=true a/... 2>&1 | wc -l) == 267 ]]
 # allow HaveLen(0)
-[[ $(./ginkgolinter --allow-havelen-0=true a/... 2>&1 | wc -l) == 2513 ]]
+[[ $(./ginkgolinter --allow-havelen-0=true a/... 2>&1 | wc -l) == 2578 ]]
 # force Expect with To
-[[ $(./ginkgolinter --force-expect-to=true a/... 2>&1 | wc -l) == 2708 ]]
+[[ $(./ginkgolinter --force-expect-to=true a/... 2>&1 | wc -l) == 2773 ]]
 # suppress all - should only return the few non-suppressble
 [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-focus-container=false --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 152 ]]
 # suppress all, force  Expect with To


### PR DESCRIPTION
# Description
Trigger warnings for directly assert the builtin `cap` function.

For example:
```go
Expect(cap(slice)).To(Equal(10)) ==> Expect(slice).To(HaveCap(10))
Expect(cap(slice) == 10).To(BeTrue()) ==> Expect(slice).To(HaveCap(10))
```

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added test case and related test data
- [x] Update the functional test

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)
