### PR TITLE
New Rule: Avoid spec Pollution

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ ginkgolinter checks the following:
 * If the first parameter is a function with the format of `func(error)bool`, ginkgolinter makes sure that the second 
   parameter exists and its type is string.
 
-### Async timing interval: timeout is shorter than polling interval [Bug]
+### Async timing interval: timeout is shorter than polling interval [BUG]
 ***Note***: Only applied when the `suppress-async-assertion` flag is **not set** *and* the `validate-async-intervals` 
 flag **is** set.
 
@@ -248,6 +248,32 @@ This will probably happen when using the old format:
    ```go
    Eventually(aFunc, 500 * time.Millisecond /*timeout*/, 10 * time.Second /*polling*/).Should(Succeed())
    ```
+
+### Avoid Spec Pollution: Don't Initialize Variables in Container Nodes [BUG/STYLE]:
+***Note***: Only applied when the `--forbid-spec-pollution=true` flag is set (disabled by default).
+
+According to [ginkgo documentation](https://onsi.github.io/ginkgo/#avoid-spec-pollution-dont-initialize-variables-in-container-nodes), 
+no variable should be assigned within a container node (`Describe`, `Context`, `When` or their `F`, `P` or `X` forms)
+  
+For example:
+```go
+var _ = Describe("description", func(){
+    var x = 10
+    ...
+})
+```
+
+Instead, use `BeforeEach()`; e.g.
+```go
+var _ = Describe("description", func (){
+    var x int
+	
+    BeforeEach(func (){
+        x = 10
+    })
+    ...
+})
+```
 
 ### Wrong Length Assertion [STYLE]
 The linter finds assertion of the golang built-in `len` function, with all kind of matchers, while there are already 
@@ -403,7 +429,7 @@ This rule support auto fixing.
 
 ***This rule is disabled by default***. Use the `--force-expect-to=true` command line flag to enable it.
 
-### Async timing interval: multiple timeout or polling intervals [Style]
+### Async timing interval: multiple timeout or polling intervals [STYLE]
 ***Note***: Only applied when the `suppress-async-assertion` flag is **not set** *and* the `validate-async-intervals`
 flag **is** set.
 
@@ -421,7 +447,7 @@ Eventually(aFunc).WithTimeout(time.Second * 10).Within(time.Second * 10).WithPol
 Eventually(aFunc, time.Second*10, time.Millisecond * 500).WithPolling(time.Millisecond * 500).Should(BeTrue())
 ```
 
-### Async timing interval: non-time.Duration intervals [Bug]
+### Async timing interval: non-time.Duration intervals [STYLE]
 ***Note***: Only applied when the `suppress-async-assertion` flag is **not set** *and* the `validate-async-intervals`
 flag **is** set.
 

--- a/analyzer.go
+++ b/analyzer.go
@@ -43,6 +43,7 @@ func NewAnalyzer() *analysis.Analyzer {
 	a.Flags.Var(&config.ForceExpectTo, "force-expect-to", "force using `Expect` with `To`, `ToNot` or `NotTo`. reject using `Expect` with `Should` or `ShouldNot`; default = false (not forced)")
 	a.Flags.BoolVar(&ignored, "suppress-focus-container", true, "Suppress warning for ginkgo focus containers like FDescribe, FContext, FWhen or FIt. Deprecated and ignored: use --forbid-focus-container instead")
 	a.Flags.Var(&config.ForbidFocus, "forbid-focus-container", "trigger a warning for ginkgo focus containers like FDescribe, FContext, FWhen or FIt; default = false.")
+	a.Flags.Var(&config.ForbidSpecPollution, "forbid-spec-pollution", "trigger a warning for variable assignments in ginkgo containers like Describe, Context and When, instead of in BeforeEach(); default = false.")
 
 	return a
 }

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -156,6 +156,19 @@ func TestFlags(t *testing.T) {
 			testData: []string{"a/timing"},
 			flags:    map[string]string{"validate-async-intervals": "true"},
 		},
+		{
+			testName: "vars in containers",
+			testData: []string{"a/vars-in-containers"},
+			flags:    map[string]string{"forbid-spec-pollution": "true"},
+		},
+		{
+			testName: "vars in containers + focus containers",
+			testData: []string{"a/containers-vas-and-focus"},
+			flags: map[string]string{
+				"forbid-spec-pollution":  "true",
+				"forbid-focus-container": "true",
+			},
+		},
 	} {
 		t.Run(tc.testName, func(tt *testing.T) {
 			analyzer := ginkgolinter.NewAnalyzer()

--- a/doc.go
+++ b/doc.go
@@ -30,6 +30,20 @@ For example:
 This will probably happen when using the old format:
 	Eventually(aFunc, 500 * time.Millisecond, 10 * time.Second).Should(Succeed())
 
+* reject variable assignments in ginkgo containers [Bug/Style]:
+For example:
+	var _ = Describe("description", func(){
+		var x = 10
+	})
+
+Should use BeforeEach instead; e.g.
+	var _ = Describe("description", func(){
+		var x int
+		BeforeEach(func(){
+			x = 10
+		})
+	})
+
 * wrong length assertions. We want to assert the item rather than its length. [Style]
 For example:
 	Expect(len(x)).Should(Equal(1))

--- a/internal/types/config.go
+++ b/internal/types/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	AllowHaveLen0          Boolean
 	ForceExpectTo          Boolean
 	ValidateAsyncIntervals Boolean
+	ForbidSpecPollution    Boolean
 }
 
 func (s *Config) AllTrue() bool {
@@ -45,6 +46,7 @@ func (s *Config) Clone() Config {
 		AllowHaveLen0:          s.AllowHaveLen0,
 		ForceExpectTo:          s.ForceExpectTo,
 		ValidateAsyncIntervals: s.ValidateAsyncIntervals,
+		ForbidSpecPollution:    s.ForbidSpecPollution,
 	}
 }
 

--- a/testdata/src/a/containers-vas-and-focus/containers.go
+++ b/testdata/src/a/containers-vas-and-focus/containers.go
@@ -1,0 +1,33 @@
+package vars_in_containers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = FDescribe("When's", func() { // want `ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code. Consider to replace with "Describe"`
+	FWhen("test FWhen", func() { // want `Focus container found. This is used only for local debug and should not be part of the actual source code. Consider to replace with "When"`
+		var x = 1 // want `use BeforeEach\(\) to assign variable x`
+		It("use x", func() {
+			Expect(x).To(Equal(1))
+		})
+	})
+})
+
+var _ = FWhen("Context's", func() { // want `ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code. Consider to replace with "When"`
+	FContext("test FContext", func() { // want `Focus container found. This is used only for local debug and should not be part of the actual source code. Consider to replace with "Context"`
+		var x = 1 // want `use BeforeEach\(\) to assign variable x`
+		It("use x", func() {
+			Expect(x).To(Equal(1))
+		})
+	})
+})
+
+var _ = FContext("Describe's", func() { // want `ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code. Consider to replace with "Context"`
+	FDescribe("test FDescribe", func() { // want `Focus container found. This is used only for local debug and should not be part of the actual source code. Consider to replace with "Describe"`
+		var x = 1 // want `use BeforeEach\(\) to assign variable x`
+		It("use x", func() {
+			Expect(x).To(Equal(1))
+		})
+	})
+})

--- a/testdata/src/a/vars-in-containers/all_containers.go
+++ b/testdata/src/a/vars-in-containers/all_containers.go
@@ -1,0 +1,98 @@
+package vars_in_containers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("When's", func() {
+	const shouldNotTriggerWarning = 1
+	const (
+		shouldNotTriggerWarningEither = 2
+	)
+
+	When("test When", func() {
+		const shouldNotTriggerWarning = 3
+		const (
+			shouldNotTriggerWarningEither = 4
+		)
+
+		var x = 1 // want `use BeforeEach\(\) to assign variable x`
+
+		It("use x", func() {
+			Expect(x).To(Equal(1))
+		})
+	})
+	FWhen("test FWhen", func() {
+		var x = 1 // want `use BeforeEach\(\) to assign variable x`
+		It("use x", func() {
+			Expect(x).To(Equal(1))
+		})
+	})
+	PWhen("test PWhen", func() {
+		var x = 1 // want `use BeforeEach\(\) to assign variable x`
+		It("use x", func() {
+			Expect(x).To(Equal(1))
+		})
+	})
+	XWhen("test XWhen", func() {
+		var x = 1 // want `use BeforeEach\(\) to assign variable x`
+		It("use x", func() {
+			Expect(x).To(Equal(1))
+		})
+	})
+})
+
+var _ = When("Context's", func() {
+	Context("test Context", func() {
+		var x = 1 // want `use BeforeEach\(\) to assign variable x`
+		It("use x", func() {
+			Expect(x).To(Equal(1))
+		})
+	})
+	FContext("test FContext", func() {
+		var x = 1 // want `use BeforeEach\(\) to assign variable x`
+		It("use x", func() {
+			Expect(x).To(Equal(1))
+		})
+	})
+	PContext("test PContext", func() {
+		var x = 1 // want `use BeforeEach\(\) to assign variable x`
+		It("use x", func() {
+			Expect(x).To(Equal(1))
+		})
+	})
+	XContext("test XContext", func() {
+		var x = 1 // want `use BeforeEach\(\) to assign variable x`
+		It("use x", func() {
+			Expect(x).To(Equal(1))
+		})
+	})
+})
+
+var _ = Context("Describe's", func() {
+	Describe("test Describe", func() {
+		var x = 1 // want `use BeforeEach\(\) to assign variable x`
+		It("use x", func() {
+			Expect(x).To(Equal(1))
+		})
+	})
+	FDescribe("test FDescribe", func() {
+		var x = 1 // want `use BeforeEach\(\) to assign variable x`
+		It("use x", func() {
+			Expect(x).To(Equal(1))
+		})
+	})
+	PDescribe("test PDescribe", func() {
+		var x = 1 // want `use BeforeEach\(\) to assign variable x`
+		It("use x", func() {
+			Expect(x).To(Equal(1))
+		})
+	})
+	XDescribe("test XDescribe", func() {
+		var x = 1 // want `use BeforeEach\(\) to assign variable x`
+		It("use x", func() {
+			Expect(x).To(Equal(1))
+		})
+	})
+})

--- a/testdata/src/a/vars-in-containers/vars.go
+++ b/testdata/src/a/vars-in-containers/vars.go
@@ -1,0 +1,81 @@
+package vars_in_containers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type Human struct {
+	Name string `json:"name"`
+	ID   string `json:"id"`
+}
+
+var _ = Describe("vars in Describe", func() {
+	var a = 1 // want `use BeforeEach\(\) to assign variable a`
+	var (
+		b = "testing" // want `use BeforeEach\(\) to assign variable b`
+		c = &Human{   // want `use BeforeEach\(\) to assign variable c`
+			Name: "someone",
+			ID:   "123456789",
+		}
+		d     string
+		valid int
+		f1    = func(i int) {
+			Expect(i).To(BeNumerically(">", 0))
+		}
+
+		g, h, valid2 int
+	)
+
+	if b == "testing" {
+		d = b // want `use BeforeEach\(\) to assign variable d`
+	} else {
+		d = "something else" // want `use BeforeEach\(\) to assign variable d`
+	}
+
+	e := 1.23 // want `use BeforeEach\(\) to assign variable e`
+
+	f2 := func(i int) {
+		Expect(i).To(BeNumerically(">", 0))
+	}
+
+	g, h = 40, 41 // want `use BeforeEach\(\) to assign variable g` `use BeforeEach\(\) to assign variable h`
+
+	BeforeEach(func() {
+		valid = 42 // valid
+	})
+
+	It("just use the vars", func() {
+		Expect(a).To(Equal(1))
+		Expect(b).To(Equal("testing"))
+		Expect(c).ToNot(BeNil())
+		Expect(d).To(Equal("testing"))
+		Expect(e).To(Equal(1.23))
+		Expect(valid).To(Equal(42))
+		Expect(valid2).To(Equal(42))
+		Expect(g).To(Equal(40))
+		Expect(h).To(Equal(41))
+		f1(valid)
+		f2(valid)
+	})
+
+	When("test When", func() {
+		var x = 1 // want `use BeforeEach\(\) to assign variable x`
+		var (
+			y     = "testing" // want `use BeforeEach\(\) to assign variable y`
+			human = &Human{   // want `use BeforeEach\(\) to assign variable human`
+				Name: "someone",
+				ID:   "123456789",
+			}
+		)
+
+		a := 1.23 // want `use BeforeEach\(\) to assign variable a`
+
+		It("just use the vars", func() {
+			Expect(x).To(Equal(1))
+			Expect(y).To(Equal("testing"))
+			Expect(human).ToNot(BeNil())
+			Expect(a).To(Equal(1.23))
+		})
+	})
+})

--- a/testdata/src/a/vars-in-containers/vars_ginkgo.go
+++ b/testdata/src/a/vars-in-containers/vars_ginkgo.go
@@ -1,0 +1,56 @@
+package vars_in_containers
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("vars in Describe", func() {
+	var x = 1 // want `use BeforeEach\(\) to assign variable x`
+	var (
+		y     = "testing" // want `use BeforeEach\(\) to assign variable y`
+		human = &Human{   // want `use BeforeEach\(\) to assign variable human`
+			Name: "someone",
+			ID:   "123456789",
+		}
+		valid int
+	)
+
+	a := 1.23 // want `use BeforeEach\(\) to assign variable a`
+
+	ginkgo.BeforeEach(func() {
+		valid = 42 // valid
+	})
+
+	ginkgo.It("just use the vars", func() {
+		Expect(x).To(Equal(1))
+		Expect(y).To(Equal("testing"))
+		Expect(human).ToNot(BeNil())
+		Expect(a).To(Equal(1.23))
+		Expect(valid).To(Equal(42))
+	})
+
+	ginkgo.When("test When", func() {
+		var x = 1 // want `use BeforeEach\(\) to assign variable x`
+		var (
+			y     = "testing" // want `use BeforeEach\(\) to assign variable y`
+			human = &Human{   // want `use BeforeEach\(\) to assign variable human`
+				Name: "someone",
+				ID:   "123456789",
+			}
+		)
+
+		a := 1.23 // want `use BeforeEach\(\) to assign variable a`
+
+		ginkgo.It("just use the vars", func() {
+			v1 := 12      // may define vars within `It`
+			var v2 = "34" // may define vars within `It`
+			Expect(x).To(Equal(1))
+			Expect(y).To(Equal("testing"))
+			Expect(human).ToNot(BeNil())
+			Expect(a).To(Equal(1.23))
+			Expect(v1).To(Equal(12))
+			Expect(v2).To(Equal("34"))
+		})
+	})
+})

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -18,7 +18,7 @@ cd testdata/src/a
 # suppress all but async
 [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 183 ]]
 # suppress all but focus
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-focus-container=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 207 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-focus-container=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 216 ]]
 # suppress all but compare different types
 [[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-compare-assertion=true a/... 2>&1 | wc -l) == 267 ]]
 # allow HaveLen(0)
@@ -31,3 +31,9 @@ cd testdata/src/a
 [[ $(./ginkgolinter --force-expect-to=true --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-focus-container=false --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 775 ]]
 # enable async interval validation
 [[ $(./ginkgolinter --validate-async-intervals=true a/... 2>&1 | wc -l) == 2686 ]]
+# suppress spec pollution
+[[ $(./ginkgolinter --forbid-spec-pollution=true a/... 2>&1 | wc -l) == 2689 ]]
+# suppress all but spec pollution
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-spec-pollution=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 250 ]]
+# suppress all but spec pollution && focus containers
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-spec-pollution=true --suppress-type-compare-assertion=true --forbid-focus-container=true a/... 2>&1 | wc -l) == 314 ]]


### PR DESCRIPTION
# Description
Does not allow variable assignments in container nodes. See here for more details: https://onsi.github.io/ginkgo/#avoid-spec-pollution-dont-initialize-variables-in-container-nodes

This rule is disabled by default. use the `--forbid-spec-pollution=true` flag to enable it.

For example, this code will trigger a warning:
```go
var _ = Describe("description", func(){
    var x = 10
    ...
})
```

Instead, use `BeforeEach()`; e.g.
```go
var _ = Describe("description", func (){
    var x int

    BeforeEach(func (){
        x = 10
    })
    ...
})
```

Closes: #136 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?
- [x] Added test case and related test data
- [x] Update the functional test

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)
