### PR TITLE
Add two new rules, to validate the `Success` and `HaveOccurred` matchers

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -25,13 +25,14 @@ func NewAnalyzerWithConfig(config *types.Config) *analysis.Analyzer {
 // NewAnalyzer returns an Analyzer - the package interface with nogo
 func NewAnalyzer() *analysis.Analyzer {
 	config := &types.Config{
-		SuppressLen:     false,
-		SuppressNil:     false,
-		SuppressErr:     false,
-		SuppressCompare: false,
-		ForbidFocus:     false,
-		AllowHaveLen0:   false,
-		ForceExpectTo:   false,
+		SuppressLen:          false,
+		SuppressNil:          false,
+		SuppressErr:          false,
+		SuppressCompare:      false,
+		ForbidFocus:          false,
+		AllowHaveLen0:        false,
+		ForceExpectTo:        false,
+		ForceSucceedForFuncs: false,
 	}
 
 	a := NewAnalyzerWithConfig(config)
@@ -50,6 +51,7 @@ func NewAnalyzer() *analysis.Analyzer {
 	a.Flags.BoolVar(&ignored, "suppress-focus-container", true, "Suppress warning for ginkgo focus containers like FDescribe, FContext, FWhen or FIt. Deprecated and ignored: use --forbid-focus-container instead")
 	a.Flags.Var(&config.ForbidFocus, "forbid-focus-container", "trigger a warning for ginkgo focus containers like FDescribe, FContext, FWhen or FIt; default = false.")
 	a.Flags.Var(&config.ForbidSpecPollution, "forbid-spec-pollution", "trigger a warning for variable assignments in ginkgo containers like Describe, Context and When, instead of in BeforeEach(); default = false.")
+	a.Flags.Var(&config.ForceSucceedForFuncs, "force-succeed", "force using the Succeed matcher for error functions, and the HaveOccurred matcher for non-function error values")
 
 	return a
 }

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -93,6 +93,10 @@ func TestAllUseCases(t *testing.T) {
 			testName: "cap",
 			testData: "a/cap",
 		},
+		{
+			testName: "HaveOccurred matcher tests",
+			testData: "a/haveoccurred",
+		},
 	} {
 		t.Run(tc.testName, func(tt *testing.T) {
 			analysistest.Run(tt, analysistest.TestData(), ginkgolinter.NewAnalyzer(), tc.testData)
@@ -167,6 +171,13 @@ func TestFlags(t *testing.T) {
 			flags: map[string]string{
 				"forbid-spec-pollution":  "true",
 				"forbid-focus-container": "true",
+			},
+		},
+		{
+			testName: "force Succeed/HaveOccurred",
+			testData: []string{"a/confighaveoccurred"},
+			flags: map[string]string{
+				"force-succeed": "true",
 			},
 		},
 	} {

--- a/doc.go
+++ b/doc.go
@@ -30,6 +30,14 @@ For example:
 This will probably happen when using the old format:
 	Eventually(aFunc, 500 * time.Millisecond, 10 * time.Second).Should(Succeed())
 
+* Success matcher validation: [BUG]
+  The Success matcher expect that the actual argument will be a single error. In async actual assertions, It also allow 
+  functions with Gomega object as the function first parameter.
+For example:
+  Expect(myInt).To(Succeed())
+or
+  Eventually(func() int { return 42 }).Should(Succeed())
+
 * reject variable assignments in ginkgo containers [Bug/Style]:
 For example:
 	var _ = Describe("description", func(){
@@ -96,4 +104,13 @@ methods.
 For example:
 	Eventually(context.Background(), func() bool { return true }, "1s").Should(BeTrue())
 	Eventually(context.Background(), func() bool { return true }, time.Second*60, 15).Should(BeTrue())
+
+* Success <=> Eventually usage [Style]
+  enforce that the Succeed() matcher will be used for error functions, and the HaveOccurred() matcher will
+  be used for error values.
+
+For example:
+  Expect(err).ToNot(Succeed())
+or
+  Expect(funcRetError().ToNot(HaveOccurred())
 `

--- a/internal/expression/actual/actual.go
+++ b/internal/expression/actual/actual.go
@@ -15,6 +15,7 @@ type Actual struct {
 	Clone        *ast.CallExpr
 	Arg          ArgPayload
 	argType      gotypes.Type
+	isTuple      bool
 	isAsync      bool
 	asyncArg     *AsyncArg
 	actualOffset int
@@ -32,6 +33,7 @@ func New(origExpr, cloneExpr *ast.CallExpr, orig *ast.CallExpr, clone *ast.CallE
 	}
 
 	argType := pass.TypesInfo.TypeOf(orig.Args[actualOffset])
+	isTuple := false
 
 	if tpl, ok := argType.(*gotypes.Tuple); ok {
 		if tpl.Len() > 0 {
@@ -39,6 +41,8 @@ func New(origExpr, cloneExpr *ast.CallExpr, orig *ast.CallExpr, clone *ast.CallE
 		} else {
 			argType = nil
 		}
+
+		isTuple = tpl.Len() > 1
 	}
 
 	isAsyncExpr := gomegainfo.IsAsyncActualMethod(funcName)
@@ -53,6 +57,7 @@ func New(origExpr, cloneExpr *ast.CallExpr, orig *ast.CallExpr, clone *ast.CallE
 		Clone:        clone,
 		Arg:          arg,
 		argType:      argType,
+		isTuple:      isTuple,
 		isAsync:      isAsyncExpr,
 		asyncArg:     asyncArg,
 		actualOffset: actualOffset,
@@ -70,6 +75,10 @@ func (a *Actual) ReplaceActualWithItsFirstArg() {
 
 func (a *Actual) IsAsync() bool {
 	return a.isAsync
+}
+
+func (a *Actual) IsTuple() bool {
+	return a.isTuple
 }
 
 func (a *Actual) ArgGOType() gotypes.Type {

--- a/internal/expression/actual/asyncfuncarg.go
+++ b/internal/expression/actual/asyncfuncarg.go
@@ -1,0 +1,37 @@
+package actual
+
+import (
+	"github.com/nunnatsa/ginkgolinter/internal/gomegahandler"
+	"github.com/nunnatsa/ginkgolinter/internal/interfaces"
+	gotypes "go/types"
+)
+
+func getAsyncFuncArg(sig *gotypes.Signature) ArgPayload {
+	argType := FuncSigArgType
+	if sig.Results().Len() == 1 {
+		if interfaces.ImplementsError(sig.Results().At(0).Type().Underlying()) {
+			argType |= ErrFuncActualArgType | ErrorTypeArgType
+		}
+	}
+
+	if sig.Params().Len() > 0 {
+		arg := sig.Params().At(0).Type()
+		if gomegahandler.IsGomegaType(arg) && sig.Results().Len() == 0 {
+			argType |= FuncSigArgType | GomegaParamArgType
+		}
+	}
+
+	if sig.Results().Len() > 1 {
+		argType |= FuncSigArgType | MultiRetsArgType
+	}
+
+	return &FuncSigArgPayload{argType: argType}
+}
+
+type FuncSigArgPayload struct {
+	argType ArgType
+}
+
+func (f FuncSigArgPayload) ArgType() ArgType {
+	return f.argType
+}

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -291,6 +291,10 @@ func (e *GomegaExpression) ActualArgTypeIs(other actual.ArgType) bool {
 	return e.actual.Arg.ArgType().Is(other)
 }
 
+func (e *GomegaExpression) IsActualTuple() bool {
+	return e.actual.IsTuple()
+}
+
 // Matcher proxies
 
 func (e *GomegaExpression) GetMatcher() *matcher.Matcher {

--- a/internal/expression/matcher/matcher.go
+++ b/internal/expression/matcher/matcher.go
@@ -24,6 +24,8 @@ const ( // gomega matchers
 	or             = "Or"
 	withTransform  = "WithTransform"
 	matchError     = "MatchError"
+	haveOccurred   = "HaveOccurred"
+	succeed        = "Succeed"
 )
 
 type Matcher struct {

--- a/internal/expression/matcher/matcherinfo.go
+++ b/internal/expression/matcher/matcherinfo.go
@@ -31,13 +31,14 @@ const (
 	MultipleMatcherMatherType
 	HaveValueMatherType
 	WithTransformMatherType
-
 	EqualBoolValueMatcherType
 	EqualValueMatcherType
+	HaveOccurredMatcherType
+	SucceedMatcherType
+	EqualNilMatcherType
+
 	BoolValueFalse
 	BoolValueTrue
-
-	EqualNilMatcherType
 
 	OrMatherType
 	AndMatherType
@@ -126,6 +127,13 @@ func getMatcherInfo(orig, clone *ast.CallExpr, matcherName string, pass *analysi
 		if m, ok := newMultipleMatchersMatcher(matcherType, orig.Args, clone.Args, pass, handler); ok {
 			return m
 		}
+
+	case succeed:
+		return &SucceedMatcher{}
+
+	case haveOccurred:
+		return &HaveOccurredMatcher{}
+
 	}
 
 	return &UnspecifiedMatcher{matcherName: matcherName}
@@ -733,4 +741,22 @@ func isFuncErrBool(t gotypes.Type) bool {
 func IsString(exp ast.Expr, pass *analysis.Pass) bool {
 	t := pass.TypesInfo.TypeOf(exp)
 	return gotypes.Identical(t, gotypes.Typ[gotypes.String])
+}
+
+type HaveOccurredMatcher struct{}
+
+func (m *HaveOccurredMatcher) Type() Type {
+	return HaveOccurredMatcherType
+}
+func (m *HaveOccurredMatcher) MatcherName() string {
+	return haveOccurred
+}
+
+type SucceedMatcher struct{}
+
+func (m *SucceedMatcher) Type() Type {
+	return SucceedMatcherType
+}
+func (m *SucceedMatcher) MatcherName() string {
+	return succeed
 }

--- a/internal/gomegahandler/handler.go
+++ b/internal/gomegahandler/handler.go
@@ -139,23 +139,27 @@ var gomegaTypeRegex = regexp.MustCompile(`github\.com/onsi/gomega/(?:internal|ty
 
 func isGomegaVar(x ast.Expr, pass *analysis.Pass) bool {
 	if tx, ok := pass.TypesInfo.Types[x]; ok {
-		var typeStr string
-		switch ttx := tx.Type.(type) {
-		case *gotypes.Pointer:
-			tp := ttx.Elem()
-			typeStr = tp.String()
-
-		case *gotypes.Named:
-			typeStr = ttx.String()
-
-		default:
-			return false
-		}
-
-		return gomegaTypeRegex.MatchString(typeStr)
+		return IsGomegaType(tx.Type)
 	}
 
 	return false
+}
+
+func IsGomegaType(t gotypes.Type) bool {
+	var typeStr string
+	switch ttx := t.(type) {
+	case *gotypes.Pointer:
+		tp := ttx.Elem()
+		typeStr = tp.String()
+
+	case *gotypes.Named:
+		typeStr = ttx.String()
+
+	default:
+		return false
+	}
+
+	return gomegaTypeRegex.MatchString(typeStr)
 }
 
 func (h dotHandler) GetActualExpr(assertionFunc *ast.SelectorExpr) *ast.CallExpr {

--- a/internal/rules/asyncsucceedrule.go
+++ b/internal/rules/asyncsucceedrule.go
@@ -1,0 +1,30 @@
+package rules
+
+import (
+	"github.com/nunnatsa/ginkgolinter/internal/expression"
+	"github.com/nunnatsa/ginkgolinter/internal/expression/actual"
+	"github.com/nunnatsa/ginkgolinter/internal/expression/matcher"
+	"github.com/nunnatsa/ginkgolinter/internal/reports"
+	"github.com/nunnatsa/ginkgolinter/types"
+)
+
+type AsyncSucceedRule struct{}
+
+func (AsyncSucceedRule) isApply(gexp *expression.GomegaExpression) bool {
+	return gexp.IsAsync() &&
+		gexp.MatcherTypeIs(matcher.SucceedMatcherType) &&
+		gexp.ActualArgTypeIs(actual.FuncSigArgType) &&
+		!gexp.ActualArgTypeIs(actual.ErrorTypeArgType|actual.GomegaParamArgType)
+}
+
+func (r AsyncSucceedRule) Apply(gexp *expression.GomegaExpression, _ types.Config, reportBuilder *reports.Builder) bool {
+	if r.isApply(gexp) {
+		if gexp.ActualArgTypeIs(actual.MultiRetsArgType) {
+			reportBuilder.AddIssue(false, "Success matcher does not support multiple values")
+		} else {
+			reportBuilder.AddIssue(false, "Success matcher only support a single error value, or function with Gomega as its first parameter")
+		}
+	}
+
+	return false
+}

--- a/internal/rules/haveoccurredrule.go
+++ b/internal/rules/haveoccurredrule.go
@@ -1,0 +1,35 @@
+package rules
+
+import (
+	"github.com/nunnatsa/ginkgolinter/internal/expression"
+	"github.com/nunnatsa/ginkgolinter/internal/expression/actual"
+	"github.com/nunnatsa/ginkgolinter/internal/expression/matcher"
+	"github.com/nunnatsa/ginkgolinter/internal/reports"
+	"github.com/nunnatsa/ginkgolinter/types"
+)
+
+type HaveOccurredRule struct{}
+
+func (r HaveOccurredRule) isApplied(gexp *expression.GomegaExpression) bool {
+	return gexp.MatcherTypeIs(matcher.HaveOccurredMatcherType)
+}
+
+func (r HaveOccurredRule) Apply(gexp *expression.GomegaExpression, config types.Config, reportBuilder *reports.Builder) bool {
+	if !r.isApplied(gexp) {
+		return false
+	}
+
+	if !gexp.ActualArgTypeIs(actual.ErrorTypeArgType) {
+		reportBuilder.AddIssue(false, "asserting a non-error type with HaveOccurred matcher")
+		return true
+	}
+
+	if bool(config.ForceSucceedForFuncs) && gexp.GetActualArg().(*actual.ErrPayload).IsFunc() {
+		gexp.ReverseAssertionFuncLogic()
+		gexp.SetMatcherSucceed()
+		reportBuilder.AddIssue(true, "prefer using the Succeed matcher for error function, instead of HaveOccurred")
+		return true
+	}
+
+	return false
+}

--- a/internal/rules/rule.go
+++ b/internal/rules/rule.go
@@ -21,6 +21,8 @@ var rules = Rules{
 	&MatchErrorRule{},
 	getMatcherOnlyRules(),
 	&EqualDifferentTypesRule{},
+	&HaveOccurredRule{},
+	&SucceedRule{},
 }
 
 var asyncRules = Rules{
@@ -28,6 +30,7 @@ var asyncRules = Rules{
 	&AsyncTimeIntervalsRule{},
 	&ErrorEqualNilRule{},
 	&MatchErrorRule{},
+	&AsyncSucceedRule{},
 	getMatcherOnlyRules(),
 }
 

--- a/internal/rules/succeedrule.go
+++ b/internal/rules/succeedrule.go
@@ -1,0 +1,41 @@
+package rules
+
+import (
+	"github.com/nunnatsa/ginkgolinter/internal/expression"
+	"github.com/nunnatsa/ginkgolinter/internal/expression/actual"
+	"github.com/nunnatsa/ginkgolinter/internal/expression/matcher"
+	"github.com/nunnatsa/ginkgolinter/internal/reports"
+	"github.com/nunnatsa/ginkgolinter/types"
+)
+
+type SucceedRule struct{}
+
+func (r SucceedRule) isApplied(gexp *expression.GomegaExpression) bool {
+	return !gexp.IsAsync() && gexp.MatcherTypeIs(matcher.SucceedMatcherType)
+}
+
+func (r SucceedRule) Apply(gexp *expression.GomegaExpression, config types.Config, reportBuilder *reports.Builder) bool {
+	if !r.isApplied(gexp) {
+		return false
+	}
+
+	if !gexp.ActualArgTypeIs(actual.ErrorTypeArgType) {
+		if gexp.IsActualTuple() {
+			reportBuilder.AddIssue(false, "the Success matcher does not support multiple values")
+		} else {
+			reportBuilder.AddIssue(false, "asserting a non-error type with Succeed matcher")
+		}
+		return true
+	}
+
+	if bool(config.ForceSucceedForFuncs) && !gexp.GetActualArg().(*actual.ErrPayload).IsFunc() {
+		gexp.ReverseAssertionFuncLogic()
+		gexp.SetMatcherHaveOccurred()
+
+		reportBuilder.AddIssue(true, "prefer using the HaveOccurred matcher for non-function error value, instead of Succeed")
+
+		return true
+	}
+
+	return false
+}

--- a/testdata/src/a/confighaveoccurred/haveoccurred.go
+++ b/testdata/src/a/confighaveoccurred/haveoccurred.go
@@ -1,0 +1,39 @@
+package haveoccurred
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("HaveOccurred", func() {
+	It("HaveOccurred for non error types", func() {
+		err := fmt.Errorf("err")
+		Expect(err).To(HaveOccurred())
+	})
+	It("HaveOccurred for non error types", func() {
+		var p *int
+		Expect(p).To(HaveOccurred()) // want `ginkgo-linter: asserting a non-error type with HaveOccurred matcher`
+	})
+
+	It("HaveOccurred for non error types", func() {
+		Expect(fmt.Errorf("err")).To(HaveOccurred()) // want `prefer using the Succeed matcher for error function, instead of HaveOccurred. Consider using .Expect\(fmt\.Errorf\("err"\)\)\.ToNot\(Succeed\(\)\). instead`
+	})
+
+})
+
+var _ = Describe("Succeed", func() {
+	It("Succeed for non error types", func() {
+		err := fmt.Errorf("err")
+		Expect(err).To(Succeed()) // want `prefer using the HaveOccurred matcher for non-function error value, instead of Succeed. Consider using .Expect\(err\)\.ToNot\(HaveOccurred\(\)\). instead`
+	})
+	It("Succeed for non error types", func() {
+		var p *int
+		Expect(p).To(Succeed()) // want `ginkgo-linter: asserting a non-error type with Succeed matcher`
+	})
+
+	It("Succeed for non error types", func() {
+		Expect(fmt.Errorf("err")).To(Succeed())
+	})
+
+})

--- a/testdata/src/a/confighaveoccurred/haveoccurred.gomega.go
+++ b/testdata/src/a/confighaveoccurred/haveoccurred.gomega.go
@@ -1,0 +1,39 @@
+package haveoccurred
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = Describe("HaveOccurred", func() {
+	It("HaveOccurred for non error types", func() {
+		err := fmt.Errorf("err")
+		gomega.Expect(err).To(gomega.HaveOccurred())
+	})
+	It("HaveOccurred for non error types", func() {
+		var p *int
+		gomega.Expect(p).To(gomega.HaveOccurred()) // want `ginkgo-linter: asserting a non-error type with HaveOccurred matcher`
+	})
+
+	It("HaveOccurred for non error types", func() {
+		gomega.Expect(fmt.Errorf("err")).To(gomega.HaveOccurred()) // want `prefer using the Succeed matcher for error function, instead of HaveOccurred. Consider using .gomega\.Expect\(fmt\.Errorf\("err"\)\)\.ToNot\(gomega\.Succeed\(\)\). instead`
+	})
+
+})
+
+var _ = Describe("Succeed", func() {
+	It("Succeed for non error types", func() {
+		err := fmt.Errorf("err")
+		gomega.Expect(err).To(gomega.Succeed()) // want `prefer using the HaveOccurred matcher for non-function error value, instead of Succeed. Consider using .gomega\.Expect\(err\)\.ToNot\(gomega\.HaveOccurred\(\)\). instead`
+	})
+	It("Succeed for non error types", func() {
+		var p *int
+		gomega.Expect(p).To(gomega.Succeed()) // want `ginkgo-linter: asserting a non-error type with Succeed matcher`
+	})
+
+	It("Succeed for non error types", func() {
+		gomega.Expect(fmt.Errorf("err")).To(gomega.Succeed())
+	})
+
+})

--- a/testdata/src/a/haveoccurred/asyncsucceed.go
+++ b/testdata/src/a/haveoccurred/asyncsucceed.go
@@ -1,0 +1,110 @@
+package haveoccurred
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func retNonErr() int {
+	return 42
+}
+
+func retOneErr() error {
+	return fmt.Errorf("err")
+}
+
+func retValAndErr() (int, error) {
+	return 42, fmt.Errorf("err")
+}
+
+func retFuncRetErr() func() error {
+	return func() error { return fmt.Errorf("err") }
+}
+
+var _ = Describe("check async with Success", func() {
+
+	localRetOneErr := func() error {
+		return fmt.Errorf("err")
+	}
+
+	localRetValAndErr := func() (int, error) {
+		return 42, fmt.Errorf("err")
+	}
+
+	It("should not trigger warnings for valid use cases", func(ctx context.Context) {
+		Eventually(func(g Gomega) {
+			g.Expect(true).To(BeTrue())
+		}, 500*time.Microsecond, 50*time.Millisecond).Should(Succeed())
+
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(true).To(BeTrue())
+		}, 500*time.Microsecond, 50*time.Millisecond).
+			WithContext(ctx).
+			Should(Succeed())
+
+		EventuallyWithOffset(1, ctx, func(g Gomega) {
+			g.Expect(true).To(BeTrue())
+		}, 500*time.Microsecond, 50*time.Millisecond).
+			WithContext(ctx).
+			Should(Succeed())
+
+		Eventually(func() error {
+			return nil
+		}).Should(Succeed())
+
+		Eventually(retOneErr).ShouldNot(Succeed())
+		Eventually(localRetOneErr).Should(Succeed())
+		Eventually(ctx, localRetOneErr).Should(Succeed())
+	})
+
+	It("should check async assertions with Succeed matcher", func(ctx context.Context) {
+		Eventually(ctx, func() int { // want `ginkgo-linter: Success matcher only support a single error value, or function with Gomega as its first parameter`
+			return 42
+		}).Should(Succeed())
+
+		Eventually(retFuncRetErr).ShouldNot(Succeed())                      // want `ginkgo-linter: Success matcher only support a single error value, or function with Gomega as its first parameter`
+		Eventually(retValAndErr).ShouldNot(Succeed())                       // want `ginkgo-linter: Success matcher does not support multiple values`
+		Eventually(localRetValAndErr).Should(Succeed())                     // want `ginkgo-linter: Success matcher does not support multiple values`
+		Eventually(ctx, localRetValAndErr).Should(Succeed())                // want `ginkgo-linter: Success matcher does not support multiple values`
+		Consistently(ctx, localRetValAndErr).Should(Succeed())              // want `ginkgo-linter: Success matcher does not support multiple values`
+		ConsistentlyWithOffset(1, ctx, localRetValAndErr).Should(Succeed()) // want `ginkgo-linter: Success matcher does not support multiple values`
+	})
+
+	It("valid inline func", func(ctx context.Context) {
+		Eventually(func(g Gomega, ctx context.Context) {
+			g.Expect(true).To(BeTrue())
+		}).WithContext(ctx).WithPolling(time.Microsecond).WithTimeout(10 * time.Millisecond).Should(Succeed())
+	})
+
+	It("invalid inline funcs: non-error ret value", func(ctx context.Context) {
+		Eventually(func(ctx context.Context) int { // want `ginkgo-linter: Success matcher only support a single error value, or function with Gomega as its first parameter`
+			return 42
+		}).WithContext(ctx).WithPolling(time.Microsecond).WithTimeout(10 * time.Millisecond).Should(Succeed())
+	})
+
+	It("invalid inline funcs: non-error ret value + Gomega var", func(ctx context.Context) {
+		Eventually(func(g Gomega, ctx context.Context) int { // want `ginkgo-linter: Success matcher only support a single error value, or function with Gomega as its first parameter`
+			g.Expect(true) // want `ginkgo-linter: "Expect": missing assertion method. Expected "To\(\)", "ToNot\(\)" or "NotTo\(\)"`
+			return 42
+		}).WithContext(ctx).WithPolling(time.Microsecond).WithTimeout(10 * time.Millisecond).Should(Succeed())
+	})
+
+	It("invalid inline funcs: multi ret values", func(ctx context.Context) {
+		Eventually(func() (int, error) { // want `ginkgo-linter: Success matcher does not support multiple values`
+			return 42, nil
+		}).WithContext(ctx).WithPolling(time.Microsecond).WithTimeout(10 * time.Millisecond).Should(Succeed())
+	})
+
+	It("invalid inline funcs: multi ret values + Gomega var", func(ctx context.Context) {
+		Eventually(retValAndErr).ShouldNot(Succeed()) // want `ginkgo-linter: Success matcher does not support multiple values`
+
+		Eventually(func(g Gomega) (int, error) { // want `ginkgo-linter: Success matcher does not support multiple values`
+			g.Expect(true).To(BeTrue())
+			return 42, nil
+		}).WithContext(ctx).WithPolling(time.Microsecond).WithTimeout(10 * time.Millisecond).Should(Succeed())
+	})
+})

--- a/testdata/src/a/haveoccurred/asyncsucceed.gomega.go
+++ b/testdata/src/a/haveoccurred/asyncsucceed.gomega.go
@@ -1,0 +1,58 @@
+package haveoccurred
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = Describe("check async with Success", func() {
+
+	localRetOneErr := func() error {
+		return fmt.Errorf("err")
+	}
+
+	localRetValAndErr := func() (int, error) {
+		return 42, fmt.Errorf("err")
+	}
+
+	It("should not trigger warnings for valid use cases", func(ctx context.Context) {
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(true).To(gomega.BeTrue())
+		}, 500*time.Microsecond, 50*time.Millisecond).Should(gomega.Succeed())
+
+		gomega.Eventually(ctx, func(g gomega.Gomega) {
+			g.Expect(true).To(gomega.BeTrue())
+		}, 500*time.Microsecond, 50*time.Millisecond).
+			WithContext(ctx).
+			Should(gomega.Succeed())
+
+		gomega.EventuallyWithOffset(1, ctx, func(g gomega.Gomega) {
+			g.Expect(true).To(gomega.BeTrue())
+		}, 500*time.Microsecond, 50*time.Millisecond).
+			WithContext(ctx).
+			Should(gomega.Succeed())
+
+		gomega.Eventually(func() error {
+			return nil
+		}).Should(gomega.Succeed())
+
+		gomega.Eventually(retOneErr).ShouldNot(gomega.Succeed())
+		gomega.Eventually(localRetOneErr).Should(gomega.Succeed())
+	})
+
+	It("should check async assertions with Succeed matcher", func(ctx context.Context) {
+		gomega.Eventually(ctx, func() int { // want `ginkgo-linter: Success matcher only support a single error value, or function with Gomega as its first parameter`
+			return 42
+		}).Should(gomega.Succeed())
+
+		gomega.Eventually(retValAndErr).ShouldNot(gomega.Succeed())                       // want `ginkgo-linter: Success matcher does not support multiple values`
+		gomega.Eventually(localRetValAndErr).Should(gomega.Succeed())                     // want `ginkgo-linter: Success matcher does not support multiple values`
+		gomega.Eventually(ctx, localRetValAndErr).Should(gomega.Succeed())                // want `ginkgo-linter: Success matcher does not support multiple values`
+		gomega.Consistently(ctx, localRetValAndErr).Should(gomega.Succeed())              // want `ginkgo-linter: Success matcher does not support multiple values`
+		gomega.ConsistentlyWithOffset(1, ctx, localRetValAndErr).Should(gomega.Succeed()) // want `ginkgo-linter: Success matcher does not support multiple values`
+	})
+})

--- a/testdata/src/a/haveoccurred/haveoccurred.go
+++ b/testdata/src/a/haveoccurred/haveoccurred.go
@@ -1,0 +1,48 @@
+package haveoccurred
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("HaveOccurred", func() {
+	It("HaveOccurred for non error types", func() {
+		err := fmt.Errorf("err")
+		Expect(err).To(HaveOccurred())
+	})
+	It("HaveOccurred for non error types", func() {
+		var p *int
+		Expect(p).To(HaveOccurred()) // want `ginkgo-linter: asserting a non-error type with HaveOccurred matcher`
+	})
+
+	It("HaveOccurred for non error types", func() {
+		Expect(fmt.Errorf("err")).To(HaveOccurred())
+	})
+
+})
+
+var _ = Describe("Succeed", func() {
+	It("valid: Succeed for error type", func() {
+		err := fmt.Errorf("err")
+		Expect(err).To(Succeed())
+	})
+
+	It("valid: Succeed for error func", func() {
+		Expect(retOneErr()).To(Succeed())
+	})
+
+	It("Succeed for non error types", func() {
+		var p *int
+		Expect(p).To(Succeed()) // want `ginkgo-linter: asserting a non-error type with Succeed matcher`
+	})
+
+	It("Succeed for non error func", func() {
+		Expect(retNonErr()).To(Succeed()) // want `ginkgo-linter: asserting a non-error type with Succeed matcher`
+	})
+
+	It("Succeed for muli-value + error func", func() {
+		Expect(retValAndErr()).To(Succeed()) // want `ginkgo-linter: the Success matcher does not support multiple values`
+	})
+
+})

--- a/testdata/src/a/haveoccurred/haveoccurred.gomega.go
+++ b/testdata/src/a/haveoccurred/haveoccurred.gomega.go
@@ -1,0 +1,39 @@
+package haveoccurred
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = Describe("HaveOccurred", func() {
+	It("HaveOccurred for non error types", func() {
+		err := fmt.Errorf("err")
+		gomega.Expect(err).To(gomega.HaveOccurred())
+	})
+	It("HaveOccurred for non error types", func() {
+		var p *int
+		gomega.Expect(p).To(gomega.HaveOccurred()) // want `ginkgo-linter: asserting a non-error type with HaveOccurred matcher`
+	})
+
+	It("HaveOccurred for non error types", func() {
+		gomega.Expect(fmt.Errorf("err")).To(gomega.HaveOccurred())
+	})
+
+})
+
+var _ = Describe("Succeed", func() {
+	It("Succeed for non error types", func() {
+		err := fmt.Errorf("err")
+		gomega.Expect(err).To(gomega.Succeed())
+	})
+	It("Succeed for non error types", func() {
+		var p *int
+		gomega.Expect(p).To(gomega.Succeed()) // want `ginkgo-linter: asserting a non-error type with Succeed matcher`
+	})
+
+	It("Succeed for non error types", func() {
+		gomega.Expect(fmt.Errorf("err")).To(gomega.Succeed())
+	})
+
+})

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -6,34 +6,36 @@ cp ginkgolinter testdata/src/a
 cd testdata/src/a
 
 # no suppress
-[[ $(./ginkgolinter a/... 2>&1 | wc -l) == 2623 ]]
+[[ $(./ginkgolinter a/... 2>&1 | wc -l) == 2652 ]]
 # suppress all but nil
-[[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1660 ]]
+[[ $(./ginkgolinter --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1689 ]]
 # suppress all but len
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1850 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1879 ]]
 # suppress all but err
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1283 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1312 ]]
 # suppress all but compare
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1263 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-async-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1292 ]]
 # suppress all but async
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1186 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1215 ]]
 # suppress all but focus
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-focus-container=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1219 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-focus-container=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1248 ]]
 # suppress all but compare different types
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-compare-assertion=true a/... 2>&1 | wc -l) == 1294 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-compare-assertion=true a/... 2>&1 | wc -l) == 1323 ]]
 # allow HaveLen(0)
-[[ $(./ginkgolinter --allow-havelen-0=true a/... 2>&1 | wc -l) == 2610 ]]
+[[ $(./ginkgolinter --allow-havelen-0=true a/... 2>&1 | wc -l) == 2639 ]]
 # force Expect with To
-[[ $(./ginkgolinter --force-expect-to=true a/... 2>&1 | wc -l) == 2815 ]]
+[[ $(./ginkgolinter --force-expect-to=true a/... 2>&1 | wc -l) == 2844 ]]
 # suppress all - should only return the few non-suppressble
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-focus-container=false --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1155 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-focus-container=false --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1184 ]]
 # suppress all, force  Expect with To
-[[ $(./ginkgolinter --force-expect-to=true --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-focus-container=false --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1776 ]]
+[[ $(./ginkgolinter --force-expect-to=true --suppress-nil-assertion=true --suppress-len-assertion=true --suppress-err-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-focus-container=false --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1805 ]]
 # enable async interval validation
-[[ $(./ginkgolinter --validate-async-intervals=true a/... 2>&1 | wc -l) == 2718 ]]
+[[ $(./ginkgolinter --validate-async-intervals=true a/... 2>&1 | wc -l) == 2753 ]]
 # suppress spec pollution
-[[ $(./ginkgolinter --forbid-spec-pollution=true a/... 2>&1 | wc -l) == 2721 ]]
+[[ $(./ginkgolinter --forbid-spec-pollution=true a/... 2>&1 | wc -l) == 2750 ]]
 # suppress all but spec pollution
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-spec-pollution=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1253 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-spec-pollution=true --suppress-type-compare-assertion=true a/... 2>&1 | wc -l) == 1282 ]]
 # suppress all but spec pollution && focus containers
-[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-spec-pollution=true --suppress-type-compare-assertion=true --forbid-focus-container=true a/... 2>&1 | wc -l) == 1317 ]]
+[[ $(./ginkgolinter --suppress-nil-assertion=true --suppress-err-assertion=true --suppress-len-assertion=true --suppress-compare-assertion=true --suppress-async-assertion=true --forbid-spec-pollution=true --suppress-type-compare-assertion=true --forbid-focus-container=true a/... 2>&1 | wc -l) == 1346 ]]
+# test --force-succeed
+[[ $(./ginkgolinter --force-succeed=true a/... 2>&1 | wc -l) == 2662 ]]

--- a/types/config.go
+++ b/types/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	ForceExpectTo          Boolean
 	ValidateAsyncIntervals Boolean
 	ForbidSpecPollution    Boolean
+	ForceSucceedForFuncs   Boolean
 }
 
 func (s *Config) AllTrue() bool {
@@ -47,6 +48,7 @@ func (s *Config) Clone() Config {
 		ForceExpectTo:          s.ForceExpectTo,
 		ValidateAsyncIntervals: s.ValidateAsyncIntervals,
 		ForbidSpecPollution:    s.ForbidSpecPollution,
+		ForceSucceedForFuncs:   s.ForceSucceedForFuncs,
 	}
 }
 


### PR DESCRIPTION
# Description
* Makes sure the `Succeed()` matcher only accepts a single error value, or a function that recieves a Gomega object as its first parameter, in async assertions.

  For example: 
  ``` go
  func retErr() error {
      return errors.New(error)
  }

  func retValAndErr() (int, error) {
      return 42, errors.New(error)
  }

  ...
  // valid
  Expect(retErr()).To(Succeed())

  Eventually(func(g Gomega) {
    v, err := retValAndErr()
    g.Expect(err).ToNot(HaveOccurred())
    g.Expect(v).To(Equal(42))
  }).To(Succeed())

  // invalid
  Expect(retValAndErr()).To(Succeed())

  Eventually(func() int {return 42}).To(Succeed())
  ```

* force usage of `Succeed` for functions, and `HaveOccurred` for values; only applied if the new command line flag: `--force-succeed=true`, is set (default: no set).

  for example:
  ```go
  Expect(retErr()).To(HaveOccurred()) ==> Expect(retErr()).ToNot(Succeed())

  // OR

  Expect(err).To(Succeed()) ==> Expect(err).ToNot(HaveOccurred())
  ```

Fixes #151 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added test case and related test data
- [x] Update the functional test

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)
