### PR TITLE
Fix two bugs: 173 and 174

### DIFF
--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -102,6 +102,10 @@ func TestAllUseCases(t *testing.T) {
 			testData: "a/issue-171",
 		},
 		{
+			testName: "respect the Error() method",
+			testData: "a/issue-173",
+		},
+		{
 			testName: "matchError with func return error-func",
 			testData: "a/issue-174",
 		},

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -101,6 +101,10 @@ func TestAllUseCases(t *testing.T) {
 			testName: "nil error-func variable",
 			testData: "a/issue-171",
 		},
+		{
+			testName: "matchError with func return error-func",
+			testData: "a/issue-174",
+		},
 	} {
 		t.Run(tc.testName, func(tt *testing.T) {
 			analysistest.Run(tt, analysistest.TestData(), ginkgolinter.NewAnalyzer(), tc.testData)

--- a/internal/expression/actual/actual.go
+++ b/internal/expression/actual/actual.go
@@ -21,13 +21,13 @@ type Actual struct {
 	actualOffset int
 }
 
-func New(origExpr, cloneExpr *ast.CallExpr, orig *ast.CallExpr, clone *ast.CallExpr, pass *analysis.Pass, handler gomegahandler.Handler, timePkg string) (*Actual, bool) {
+func New(origExpr, cloneExpr *ast.CallExpr, orig *ast.CallExpr, clone *ast.CallExpr, pass *analysis.Pass, handler gomegahandler.Handler, timePkg string, errMethodExists bool) (*Actual, bool) {
 	funcName, ok := handler.GetActualFuncName(orig)
 	if !ok {
 		return nil, false
 	}
 
-	arg, actualOffset := getActualArgPayload(orig, clone, pass, funcName)
+	arg, actualOffset := getActualArgPayload(orig, clone, pass, funcName, errMethodExists)
 	if arg == nil {
 		return nil, false
 	}

--- a/internal/expression/actual/actualarg.go
+++ b/internal/expression/actual/actualarg.go
@@ -56,18 +56,20 @@ func getActualArgPayload(origActualExpr, actualExprClone *ast.CallExpr, pass *an
 
 		case *ast.BinaryExpr:
 			arg = parseBinaryExpr(expr, argExprClone.(*ast.BinaryExpr), pass)
-
-		default:
-			t := pass.TypesInfo.TypeOf(origArgExpr)
-			if sig, ok := t.(*gotypes.Signature); ok {
-				arg = getAsyncFuncArg(sig)
-			}
 		}
 
 	}
 
 	if arg != nil {
 		return arg, actualOffset
+	}
+
+	t := pass.TypesInfo.TypeOf(origArgExpr)
+	if sig, ok := t.(*gotypes.Signature); ok {
+		arg = getAsyncFuncArg(sig)
+		if arg != nil {
+			return arg, actualOffset
+		}
 	}
 
 	return newRegularArgPayload(origArgExpr, argExprClone, pass), actualOffset

--- a/internal/expression/actual/actualarg.go
+++ b/internal/expression/actual/actualarg.go
@@ -28,6 +28,7 @@ const (
 	ErrFuncActualArgType
 	GomegaParamArgType
 	MultiRetsArgType
+	ErrorMethodArgType
 
 	ErrorTypeArgType
 
@@ -39,7 +40,7 @@ func (a ArgType) Is(val ArgType) bool {
 	return a&val != 0
 }
 
-func getActualArgPayload(origActualExpr, actualExprClone *ast.CallExpr, pass *analysis.Pass, actualMethodName string) (ArgPayload, int) {
+func getActualArgPayload(origActualExpr, actualExprClone *ast.CallExpr, pass *analysis.Pass, actualMethodName string, errMethodExists bool) (ArgPayload, int) {
 	origArgExpr, argExprClone, actualOffset, isGomegaExpr := getActualArg(origActualExpr, actualExprClone, actualMethodName, pass)
 	if !isGomegaExpr {
 		return nil, 0
@@ -47,7 +48,9 @@ func getActualArgPayload(origActualExpr, actualExprClone *ast.CallExpr, pass *an
 
 	var arg ArgPayload
 
-	if value.IsExprError(pass, origArgExpr) {
+	if errMethodExists {
+		arg = &ErrorMethodPayload{}
+	} else if value.IsExprError(pass, origArgExpr) {
 		arg = newErrPayload(origArgExpr, argExprClone, pass)
 	} else {
 		switch expr := origArgExpr.(type) {
@@ -181,6 +184,12 @@ func newErrPayload(orig, clone ast.Expr, pass *analysis.Pass) *ErrPayload {
 
 func (*ErrPayload) ArgType() ArgType {
 	return ErrActualArgType | ErrorTypeArgType
+}
+
+type ErrorMethodPayload struct{}
+
+func (ErrorMethodPayload) ArgType() ArgType {
+	return ErrorMethodArgType | ErrorTypeArgType
 }
 
 func parseBinaryExpr(origActualExpr, argExprClone *ast.BinaryExpr, pass *analysis.Pass) ArgPayload {

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -52,7 +52,9 @@ func New(origExpr *ast.CallExpr, pass *analysis.Pass, handler gomegahandler.Hand
 	exprClone := astcopy.CallExpr(origExpr)
 	selClone := exprClone.Fun.(*ast.SelectorExpr)
 
-	origActual := handler.GetActualExpr(origSel)
+	errMethodExists := false
+
+	origActual := handler.GetActualExpr(origSel, &errMethodExists)
 	if origActual == nil {
 		return nil, false
 	}
@@ -62,7 +64,7 @@ func New(origExpr *ast.CallExpr, pass *analysis.Pass, handler gomegahandler.Hand
 		return nil, false
 	}
 
-	actl, ok := actual.New(origExpr, exprClone, origActual, actualClone, pass, handler, timePkg)
+	actl, ok := actual.New(origExpr, exprClone, origActual, actualClone, pass, handler, timePkg, errMethodExists)
 	if !ok {
 		return nil, false
 	}

--- a/internal/gomegahandler/dothandler.go
+++ b/internal/gomegahandler/dothandler.go
@@ -51,7 +51,7 @@ func (dotHandler) GetNewWrapperMatcher(name string, existing *ast.CallExpr) *ast
 	}
 }
 
-func (h dotHandler) GetActualExpr(assertionFunc *ast.SelectorExpr) *ast.CallExpr {
+func (h dotHandler) GetActualExpr(assertionFunc *ast.SelectorExpr, errMethodExists *bool) *ast.CallExpr {
 	actualExpr, ok := assertionFunc.X.(*ast.CallExpr)
 	if !ok {
 		return nil
@@ -66,7 +66,11 @@ func (h dotHandler) GetActualExpr(assertionFunc *ast.SelectorExpr) *ast.CallExpr
 				return actualExpr
 			}
 		} else {
-			return h.GetActualExpr(fun)
+			if fun.Sel.Name == "Error" {
+				*errMethodExists = true
+			}
+
+			return h.GetActualExpr(fun, errMethodExists)
 		}
 	}
 	return nil

--- a/internal/gomegahandler/handler.go
+++ b/internal/gomegahandler/handler.go
@@ -18,7 +18,7 @@ type Handler interface {
 	// ReplaceFunction replaces the function with another one, for fix suggestions
 	ReplaceFunction(*ast.CallExpr, *ast.Ident)
 
-	GetActualExpr(assertionFunc *ast.SelectorExpr) *ast.CallExpr
+	GetActualExpr(assertionFunc *ast.SelectorExpr, errMethodExists *bool) *ast.CallExpr
 
 	GetActualExprClone(origFunc, funcClone *ast.SelectorExpr) *ast.CallExpr
 

--- a/internal/gomegahandler/namedhandler.go
+++ b/internal/gomegahandler/namedhandler.go
@@ -51,7 +51,7 @@ func (g nameHandler) isGomegaVar(x ast.Expr) bool {
 	return gomegainfo.IsGomegaVar(x, g.pass)
 }
 
-func (g nameHandler) GetActualExpr(assertionFunc *ast.SelectorExpr) *ast.CallExpr {
+func (g nameHandler) GetActualExpr(assertionFunc *ast.SelectorExpr, errMethodExists *bool) *ast.CallExpr {
 	actualExpr, ok := assertionFunc.X.(*ast.CallExpr)
 	if !ok {
 		return nil
@@ -69,7 +69,10 @@ func (g nameHandler) GetActualExpr(assertionFunc *ast.SelectorExpr) *ast.CallExp
 				return actualExpr
 			}
 		} else {
-			return g.GetActualExpr(fun)
+			if fun.Sel.Name == "Error" {
+				*errMethodExists = true
+			}
+			return g.GetActualExpr(fun, errMethodExists)
 		}
 	}
 	return nil

--- a/testdata/src/a/issue-173/issue173.go
+++ b/testdata/src/a/issue-173/issue173.go
@@ -1,0 +1,25 @@
+package issue_173
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func intErrFunc() (int, error) {
+	return 42, nil
+}
+
+func strErr() (string, error) {
+	return "", errors.New("error")
+}
+
+var _ = Describe("test if issue 173 was solved", func() {
+	It("should respect the Error() method", func() {
+		Expect(intErrFunc()).Error().To(BeNil()) // want `ginkgo-linter: wrong error assertion. Consider using .Expect\(intErrFunc\(\)\)\.Error\(\)\.ToNot\(HaveOccurred\(\)\). instead`
+		Expect(intErrFunc()).Error().ToNot(HaveOccurred())
+		Expect(intErrFunc()).Error().ToNot(Succeed())
+		Expect(strErr()).Error().To(MatchError(ContainSubstring("error")))
+	})
+})

--- a/testdata/src/a/issue-174/issue174.go
+++ b/testdata/src/a/issue-174/issue174.go
@@ -1,0 +1,20 @@
+package issue_171
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func errFunc() func() error {
+	return func() error {
+		return errors.New("error")
+	}
+}
+
+var _ = Describe("test if issue 174 was solved", func() {
+	It("should not trigger", func() {
+		Eventually(errFunc()).Should(MatchError(ContainSubstring("error")))
+	})
+})


### PR DESCRIPTION
# Description

## Bug fix: false positive for func returns error func
The linter triggers a warning for this case:
```go
func errFunc() func() error {
	return func() error {
		return errors.New("error")
	}
}

var _ = Describe("test if issue 174 was solved", func() {
	It("should not trigger", func() {
		Eventually(errFunc()).Should(MatchError(ContainSubstring("error")))
	})
})
```

The linter fails to identify the actual value as error value.

Fixes #174

## Fix bug: ginkgolinter ignores the Error() method

as in:

```go
Expect(func() (int, error) {return 42, nil}()).Error().ToNot(HaveOccurred())
```
Fixes #173 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactoring

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added test case and related test data
- [ ] Update the functional test

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran `make goimports`
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)
