### PR TITLE
fix: downgrade min Go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/nunnatsa/ginkgolinter
 
-go 1.22.9
+go 1.22.0
+
+toolchain go1.22.9
 
 require (
 	github.com/go-toolsmith/astcopy v1.1.0


### PR DESCRIPTION
# Description

The min Go version is a hard requirement for lib consumers.

This version defines the minimum language version, so patch versions are globally useless in this case.

The Go version inside `toolchain` defined the Go version used to compile and doesn't affect lib consumers.

## Type of change

Revert go.mod changes from #172

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I ran `make goimports`
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)

@nunnatsa
