### PR TITLE
fix typos in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ The `Equal` and the `BeIdentical` matchers also check the type, not only the val
 The following code will fail in runtime:    
 ```go
 x := 5 // x is int
-Expect(x).Should(Eqaul(uint(5)) // x and uint(5) are with different
+Expect(x).Should(Equal(uint(5)) // x and uint(5) are with different
 ```
 When using negative checks, it's even worse, because we get a false positive:
 ```
@@ -234,7 +234,7 @@ flag **is** set.
 ***Note***: This rule work with best-effort approach. It can't find many cases, like const defined not in the same
 package, or when using variables.
 
-The timeout and polling intervals may be passed as optional arguments to the `Eventually` or `Constanly` functions, or
+The timeout and polling intervals may be passed as optional arguments to the `Eventually` or `Consistently` functions, or
 using the `WithTimeout` or , `Within` methods (timeout), and `WithPolling` or `ProbeEvery` methods (polling).
 
 This rule checks if the async (`Eventually` or `Consistently`) timeout duration, is not shorter than the polling interval.
@@ -457,7 +457,7 @@ This rule support auto fixing.
 ***Note***: Only applied when the `suppress-async-assertion` flag is **not set** *and* the `validate-async-intervals`
 flag **is** set.
 
-The timeout and polling intervals may be passed as optional arguments to the `Eventually` or `Constanly` functions, or
+The timeout and polling intervals may be passed as optional arguments to the `Eventually` or `Consistently` functions, or
 using the `WithTimeout` or , `Within` methods (timeout), and `WithPolling` or `ProbeEvery` methods (polling).
 
 The linter checks that there is up to one polling argument and up to one timeout argument. 
@@ -475,7 +475,7 @@ Eventually(aFunc, time.Second*10, time.Millisecond * 500).WithPolling(time.Milli
 ***Note***: Only applied when the `suppress-async-assertion` flag is **not set** *and* the `validate-async-intervals`
 flag **is** set.
 
-gomega supports a few formats for timeout and polling intervals, when using the old format (the last two parameters of Eventually and Constantly):
+gomega supports a few formats for timeout and polling intervals, when using the old format (the last two parameters of Eventually and Consistently):
 * a `time.Duration` value
 * any kind of numeric value (int(8/16/32/64), uint(8/16/32/64) or float(32/64), as the number of seconds.
 * duration string like `"12s"`
@@ -559,7 +559,7 @@ To suppress the wrong async assertion warning, add a comment with (only)
 
 `ginkgo-linter:ignore-async-assert-warning`. 
 
-To supress the focus container warning, add a comment with (only)
+To suppress the focus container warning, add a comment with (only)
 
 `ginkgo-linter:ignore-focus-container-warning`
 
@@ -572,10 +572,10 @@ Notice that this comment will not work for an anonymous variable container like
 // ginkgo-linter:ignore-focus-container-warning (not working!!)
 var _ = FDescribe(...)
 ```
-In this case, use the file comment (see bellow).
+In this case, use the file comment (see below).
 
 There are two options to use these comments:
-1. If the comment is at the top of the file, supress the warning for the whole file; e.g.:
+1. If the comment is at the top of the file, suppress the warning for the whole file; e.g.:
    ```go
    package mypackage
    

--- a/doc.go
+++ b/doc.go
@@ -94,7 +94,7 @@ For example:
 	Eventually(func() bool { return true }, time.Second*10, 500*time.Millisecond).ProbeEvery(time.Millisecond * 500).Should(BeTrue())
 
 * async timing interval: non-time.Duration intervals [Style]
-gomega supports a few formats for timeout and polling intervals, when using the old format (the last two parameters of Eventually and Constantly):
+gomega supports a few formats for timeout and polling intervals, when using the old format (the last two parameters of Eventually and Consistently):
   * time.Duration
   * any kind of numeric value, as number of seconds
   * duration string like "12s"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -32,7 +32,7 @@ internal/
         + actual - types to model the actual part of the gomega assertion expression
         + matcher - types to model the matcher part of the gomega assertion expression
         + value - models a value in several actual and matcher types
-    + rules - the gomega linter rules. A rule recieves a gomega expression and trigger a linter error if needed. 
+    + rules - the gomega linter rules. A rule receives a gomega expression and trigger a linter error if needed. 
     ...
 ... 
 ```


### PR DESCRIPTION
# Description

Corrects grammar mistakes in `README.md`, `CONTRIBUTING.md` and `docs/doc.go`.

`Constantly` changed to `Consistently`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactoring

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran `make goimports`
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)

@nunnatsa
