### PR TITLE
Fix false positive when asserting an error pointer

### DIFF
--- a/internal/expression/value/value.go
+++ b/internal/expression/value/value.go
@@ -194,6 +194,10 @@ func IsExprError(pass *analysis.Pass, expr ast.Expr) bool {
 		return interfaces.ImplementsError(actualArgType)
 
 	case *gotypes.Pointer:
+		if interfaces.ImplementsError(t) {
+			return true
+		}
+
 		if tt, ok := t.Elem().(*gotypes.Named); ok {
 			return interfaces.ImplementsError(tt)
 		}

--- a/testdata/src/a/haveoccurred/haveoccurred.go
+++ b/testdata/src/a/haveoccurred/haveoccurred.go
@@ -47,3 +47,38 @@ var _ = Describe("Succeed", func() {
 	})
 
 })
+
+type myError struct {
+	e string
+}
+
+func (e *myError) Error() string {
+	return e.e
+}
+
+func retErr(str string) *myError {
+	return &myError{e: str}
+}
+
+var _ = Describe("pointer error", func() {
+	Context("err pointer var", func() {
+		It("should not trigger warning", func() {
+			err := &myError{e: "err"}
+			Expect(err).To(HaveOccurred())
+		})
+
+	})
+
+	Context("returned value", func() {
+		It("should not trigger warning", func() {
+			err := retErr("err")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("Succeed", func() {
+		It("should not trigger warning", func() {
+			Expect(retErr("err")).ToNot(Succeed())
+		})
+	})
+})


### PR DESCRIPTION
# Description
When using a pointer as an error, like in:

```go
type myErr struct {
    code int
}

func (e *myErr) Error() string {
    ...
}

...
err = &myErr{code: 404}
Expect(err).To(HaveOccured())
```

ginkgolinter mistakely detects `err` as not error type.

This PR fixes this issue.

Fixes #183
Originally found here: https://github.com/containernetworking/cni/issues/1148

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactoring

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added test case and related test data
- [ ] Update the functional test

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran `make goimports`
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)
