### PR TITLE
Improve IsGomegaVar() and IsGomegaType()

### DIFF
--- a/internal/gomegainfo/gomegainfo.go
+++ b/internal/gomegainfo/gomegainfo.go
@@ -86,30 +86,35 @@ func IsAssertionFunc(name string) bool {
 }
 
 func IsGomegaVar(x ast.Expr, pass *analysis.Pass) bool {
-	if tx, ok := pass.TypesInfo.Types[x]; ok {
-		return IsGomegaType(tx.Type)
-	}
-
-	return false
-}
-
-func IsGomegaType(t gotypes.Type) bool {
-	var typeStr string
-	switch ttx := t.(type) {
-	case *gotypes.Pointer:
-		tp := ttx.Elem()
-		typeStr = tp.String()
-
-	case *gotypes.Named:
-		typeStr = ttx.String()
-
-	case *gotypes.Alias:
-		typeStr = ttx.String()
-
-	default:
+	if _, isIdent := x.(*ast.Ident); !isIdent {
 		return false
 	}
 
-	return strings.Contains(typeStr, "github.com/onsi/gomega") &&
-		(strings.HasSuffix(typeStr, "Gomega") || strings.HasSuffix(typeStr, "WithT"))
+	tx, ok := pass.TypesInfo.Types[x]
+	if !ok {
+		return false
+	}
+
+	return IsGomegaType(tx.Type)
+}
+
+const (
+	gomegaStructType = "github.com/onsi/gomega/internal.Gomega"
+	gomegaInterface  = "github.com/onsi/gomega/types.Gomega"
+)
+
+func IsGomegaType(t gotypes.Type) bool {
+	switch ttx := t.(type) {
+	case *gotypes.Pointer:
+		return IsGomegaType(ttx.Elem())
+
+	case *gotypes.Named:
+		name := ttx.String()
+		return strings.HasSuffix(name, gomegaStructType) || strings.HasSuffix(name, gomegaInterface)
+
+	case *gotypes.Alias:
+		return IsGomegaType(ttx.Rhs())
+	}
+
+	return false
 }


### PR DESCRIPTION
# Description
Don't check non ast.Ident expressions for been Gomega variables.

Make more accurate check for the Gomega types (struct or interface). check the alias value instead of the alias.

Got a bit better performance.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactoring

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added test case and related test data
- [ ] Update the functional test

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran `make goimports`
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)
