### PR TITLE
Fix issue: failed to recognize ginkgo.SpecContext in Eventually

### DIFF
--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -109,6 +109,10 @@ func TestAllUseCases(t *testing.T) {
 			testName: "matchError with func return error-func",
 			testData: "a/issue-174",
 		},
+		{
+			testName: "matchError with func with SpecContext",
+			testData: "a/issue-190",
+		},
 	} {
 		t.Run(tc.testName, func(tt *testing.T) {
 			analysistest.Run(tt, analysistest.TestData(), ginkgolinter.NewAnalyzer(), tc.testData)

--- a/internal/expression/actual/actualarg.go
+++ b/internal/expression/actual/actualarg.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/tools/go/analysis"
 
 	"github.com/nunnatsa/ginkgolinter/internal/expression/value"
+	"github.com/nunnatsa/ginkgolinter/internal/ginkgoinfo"
 	"github.com/nunnatsa/ginkgolinter/internal/gomegahandler"
 	"github.com/nunnatsa/ginkgolinter/internal/gomegainfo"
 	"github.com/nunnatsa/ginkgolinter/internal/reverseassertion"
@@ -98,7 +99,7 @@ func getActualArg(origActualExpr *ast.CallExpr, actualExprClone *ast.CallExpr, a
 	argExprClone = actualExprClone.Args[funcOffset]
 
 	if gomegainfo.IsAsyncActualMethod(actualMethodName) {
-		if pass.TypesInfo.TypeOf(origArgExpr).String() == "context.Context" {
+		if ginkgoinfo.IsGinkgoContext(pass.TypesInfo.TypeOf(origArgExpr)) {
 			funcOffset++
 			if len(origActualExpr.Args) <= funcOffset {
 				return nil, nil, 0, false

--- a/internal/ginkgoinfo/ginkgoinfo.go
+++ b/internal/ginkgoinfo/ginkgoinfo.go
@@ -1,0 +1,26 @@
+package ginkgoinfo
+
+import (
+	gotypes "go/types"
+	"strings"
+)
+
+const (
+	ctxTypeName     = "context.Context"
+	ginkgoCtxSuffix = "github.com/onsi/ginkgo/v2/internal.SpecContext"
+)
+
+func IsGinkgoContext(t gotypes.Type) bool {
+	maybeCtx := gotypes.Unalias(t)
+
+	typeName := maybeCtx.String()
+	if typeName == ctxTypeName {
+		return true
+	}
+
+	if strings.HasSuffix(typeName, ginkgoCtxSuffix) {
+		return true
+	}
+
+	return false
+}

--- a/testdata/src/a/issue-190/issue190.go
+++ b/testdata/src/a/issue-190/issue190.go
@@ -1,0 +1,25 @@
+package issue_190
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("make sure issue 190 is fixed", func() {
+	It("should work", func(ctx context.Context) {
+		Eventually(ctx, func() error {
+			return fmt.Errorf("foo")
+		}).Should(MatchError("foo"))
+	}, SpecTimeout(time.Second))
+
+	It("should work", func(ctx SpecContext) {
+		Eventually(ctx, func() error {
+			return fmt.Errorf("foo")
+		}).Should(MatchError("foo"))
+	}, SpecTimeout(time.Second))
+})

--- a/testdata/src/a/issue-190/issue190.gomega.go
+++ b/testdata/src/a/issue-190/issue190.gomega.go
@@ -1,0 +1,24 @@
+package issue_190
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/onsi/gomega"
+)
+
+var _ = Describe("", func() {
+	It("should work", func(ctx SpecContext) {
+		gomega.Eventually(ctx, func() error {
+			return fmt.Errorf("foo")
+		}).Should(gomega.MatchError("foo"))
+	}, SpecTimeout(time.Second))
+	It("should work", func(ctx context.Context) {
+		gomega.Eventually(ctx, func() error {
+			return fmt.Errorf("foo")
+		}).Should(gomega.MatchError("foo"))
+	}, SpecTimeout(time.Second))
+})


### PR DESCRIPTION
# Description
ginkgolinter fails to recognized ginkgo.SpecContext as a valid context in Eventually, and so wrongly identify it as the actual value, instead of the following function parameter.

This PR fixes the issue and now this scenarion works

```go
It("should work", func(ctx SpecContext) {
	Eventually(func() error {
		return fmt.Errorf("foo")
	}).WithContext(ctx).Should(MatchError("foo"))
}, SpecTimeout(time.Second))
```
Fixes #190

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactoring

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added test case and related test data
- [ ] Update the functional test

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran `make goimports`
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)
