### PR TITLE
Fix typos in tests and constants

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,7 @@ const (
 	suppressNilAssertionWarning     = suppressPrefix + "ignore-nil-assert-warning"
 	suppressErrAssertionWarning     = suppressPrefix + "ignore-err-assert-warning"
 	suppressCompareAssertionWarning = suppressPrefix + "ignore-compare-assert-warning"
-	suppressAsyncAsertWarning       = suppressPrefix + "ignore-async-assert-warning"
+	suppressAsyncAssertWarning      = suppressPrefix + "ignore-async-assert-warning"
 	suppressFocusContainerWarning   = suppressPrefix + "ignore-focus-container-warning"
 	suppressTypeCompareWarning      = suppressPrefix + "ignore-type-compare-warning"
 )
@@ -77,7 +77,7 @@ func (s *Config) UpdateFromComment(commentGroup []*ast.CommentGroup) {
 					s.SuppressErr = true
 				case suppressCompareAssertionWarning:
 					s.SuppressCompare = true
-				case suppressAsyncAsertWarning:
+				case suppressAsyncAssertWarning:
 					s.SuppressAsync = true
 				case suppressFocusContainerWarning:
 					s.ForbidFocus = false

--- a/internal/reverseassertion/reverse_assertion_test.go
+++ b/internal/reverseassertion/reverse_assertion_test.go
@@ -28,20 +28,20 @@ func TestChangeAssertionLogic(t *testing.T) {
 func TestChangeAssertionLogicWithNotTo(t *testing.T) {
 	rev := reverseassertion.ChangeAssertionLogic("NotTo")
 	if rev != "To" {
-		t.Errorf("reverced function of NotTo should be NotTo, but it's %s", rev)
+		t.Errorf("reversed function of NotTo should be NotTo, but it's %s", rev)
 	}
 
 	revRev := reverseassertion.ChangeAssertionLogic(rev)
 
 	if revRev != "ToNot" {
-		t.Errorf("reverced function of To should be ToNot, but it's %s", revRev)
+		t.Errorf("reversed function of To should be ToNot, but it's %s", revRev)
 	}
 }
 
 func TestChangeAssertionLogicWithUnknown(t *testing.T) {
 	rev := reverseassertion.ChangeAssertionLogic("unknown")
 	if rev != "unknown" {
-		t.Errorf("reverced function of unknown should be the same, but it's %s", rev)
+		t.Errorf("reversed function of unknown should be the same, but it's %s", rev)
 	}
 }
 

--- a/testdata/src/a/focusconfig/focus_test.go
+++ b/testdata/src/a/focusconfig/focus_test.go
@@ -56,7 +56,7 @@ var _ = Describe("should ignore", func() {
 
 var _ = Describe("suppress", func() {
 	// ginkgo-linter:ignore-focus-container-warning
-	FContext("supress", func() {
+	FContext("suppress", func() {
 		// ginkgo-linter:ignore-focus-container-warning
 		FWhen("suppress", func() {
 			// ginkgo-linter:ignore-focus-container-warning

--- a/testdata/src/a/suppress/a.go
+++ b/testdata/src/a/suppress/a.go
@@ -5,7 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Supress wrong length check", func() {
+var _ = Describe("Suppress wrong length check", func() {
 	Context("test ginkgo-linter:ignore-len-assert-warning", func() {
 		It("should ignore length warning", func() {
 			// ginkgo-linter:ignore-len-assert-warning

--- a/testdata/src/a/suppress/eventually.comment.go
+++ b/testdata/src/a/suppress/eventually.comment.go
@@ -25,7 +25,7 @@ var _ = Describe("should suppress async assertions", func() {
 		Eventually(slowInt()).Should(Equal(42))
 	})
 
-	It("should suppress async assertions, but not Eqaul(true)", func() {
+	It("should suppress async assertions, but not Equal(true)", func() {
 		Eventually(slowBool()).Should(Equal(true)) // want `ginkgo-linter: multiple issues: use a function call in Eventually\. This actually checks nothing, because Eventually receives the function returned value, instead of function itself, and this value is never changed; wrong boolean assertion\. Consider using .Eventually\(slowBool\)\.Should\(BeTrue\(\)\). instead`
 
 		// ginkgo-linter:ignore-async-assert-warning

--- a/testdata/src/a/suppress/eventually.file.go
+++ b/testdata/src/a/suppress/eventually.file.go
@@ -12,7 +12,7 @@ var _ = Describe("should suppress async assertions", func() {
 		Eventually(slowInt()).Should(Equal(42))
 	})
 
-	It("should suppress async assertions, but not Eqaul(true)", func() {
+	It("should suppress async assertions, but not Equal(true)", func() {
 		Eventually(slowBool()).Should(Equal(true)) // want `ginkgo-linter: wrong boolean assertion\. Consider using .Eventually\(slowBool\(\)\)\.Should\(BeTrue\(\)\). instead`
 	})
 })


### PR DESCRIPTION
# Description

Fixes typos.

## Type of change

- [x] Refactoring

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran `make goimports`
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)

@nunnatsa
