### PR TITLE
Added new rule: To and Not

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,12 @@ Eventually(func() {
 
 ***This rule is disabled by default***. Use the `--force-assertion-description` command line flag to enable it.
 
+### Force NotTo() [STYLE]
+This rule enforces using the `NotTo()` or `ShouldNot()` assertion methods instead of `To(Not())` 
+or `Should(Not())`.
+
+***This rule is disabled by default***. Use the `--force-tonot` command line flag to enable it.
+
 ## Suppress the linter
 ### Suppress warning from command line
 * Use the `--suppress-len-assertion` flag to suppress the wrong length and cap assertions warning

--- a/analyzer.go
+++ b/analyzer.go
@@ -52,6 +52,7 @@ func NewAnalyzer() *analysis.Analyzer {
 	a.Flags.BoolVar(&config.ForbidSpecPollution, "forbid-spec-pollution", config.ForbidSpecPollution, "trigger a warning for variable assignments in ginkgo containers like Describe, Context and When, instead of in BeforeEach(); default = false.")
 	a.Flags.BoolVar(&config.ForceSucceedForFuncs, "force-succeed", config.ForceSucceedForFuncs, "force using the Succeed matcher for error functions, and the HaveOccurred matcher for non-function error values")
 	a.Flags.BoolVar(&config.ForceAssertionDescription, "force-assertion-description", config.ForceAssertionDescription, "force adding assertion descriptions to gomega matchers; default = false")
+	a.Flags.BoolVar(&config.ForeToNot, "force-tonot", config.ForeToNot, "force using `ToNot`, `ShouldNot` instead of To(Not()); default = false")
 
 	return a
 }

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -201,6 +201,11 @@ func TestFlags(t *testing.T) {
 			testData: []string{"a/assertiondescription"},
 			flags:    map[string]string{"force-assertion-description": "true"},
 		},
+		{
+			testName: "simplify To(Not()) expressions",
+			testData: []string{"a/to_and_not"},
+			flags:    map[string]string{"force-tonot": "true"},
+		},
 	} {
 		t.Run(tc.testName, func(tt *testing.T) {
 			analyzer := ginkgolinter.NewAnalyzer()

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	ForbidSpecPollution       bool
 	ForceSucceedForFuncs      bool
 	ForceAssertionDescription bool
+	ForeToNot                 bool
 }
 
 func (s *Config) AllTrue() bool {
@@ -51,6 +52,7 @@ func (s *Config) Clone() Config {
 		ForbidSpecPollution:       s.ForbidSpecPollution,
 		ForceSucceedForFuncs:      s.ForceSucceedForFuncs,
 		ForceAssertionDescription: s.ForceAssertionDescription,
+		ForeToNot:                 s.ForeToNot,
 	}
 }
 

--- a/doc.go
+++ b/doc.go
@@ -106,7 +106,7 @@ For example:
 	Eventually(context.Background(), func() bool { return true }, time.Second*60, 15).Should(BeTrue())
 
 * Success <=> Eventually usage [Style]
-  enforce that the Succeed() matcher will be used for error functions, and the HaveOccurred() matcher will
+  enforces that the Succeed() matcher will be used for error functions, and the HaveOccurred() matcher will
   be used for error values.
 
 For example:
@@ -115,7 +115,7 @@ or
   Expect(funcRetError().ToNot(HaveOccurred())
 
 * force assertion descriptions [Style]
-  enforce that all assertions include an optional description message to improve test readability and debugging.
+  enforces that all assertions include an optional description message to improve test readability and debugging.
   This rule is disabled by default. Use the --force-assertion-description flag to enable it.
 
 For example:
@@ -127,4 +127,7 @@ The rule also works with async assertions and Expect calls inside Eventually:
   Eventually(func() {
     Expect(value).To(Equal(expected)) // This will also trigger a warning if no description
   }).Should(Succeed(), "operation should complete successfully")
+
+* Force ToNot [Style]
+  enforces that ToNot() or ShouldNot() are used instead of To(Not()) or Should(Not()).
 `

--- a/internal/rules/matcheronlyrule.go
+++ b/internal/rules/matcheronlyrule.go
@@ -7,6 +7,8 @@ var matcherOnlyRules = Rules{
 	&EqualBoolRule{},
 	&EqualNilRule{},
 	&DoubleNegativeRule{},
+	// must be the last rule in the list
+	&SimplifyNotRule{},
 }
 
 func getMatcherOnlyRules() Rules {

--- a/internal/rules/simplify_not.go
+++ b/internal/rules/simplify_not.go
@@ -1,0 +1,21 @@
+package rules
+
+import (
+	"github.com/nunnatsa/ginkgolinter/config"
+	"github.com/nunnatsa/ginkgolinter/internal/expression"
+	"github.com/nunnatsa/ginkgolinter/internal/reports"
+)
+
+type SimplifyNotRule struct{}
+
+func (r *SimplifyNotRule) Apply(gexp *expression.GomegaExpression, config config.Config, reportBuilder *reports.Builder) bool {
+	if !r.isApplied(gexp, config) {
+		return false
+	}
+	reportBuilder.AddIssue(true, "simplify negation by removing the 'Not' matcher")
+	return true
+}
+
+func (r *SimplifyNotRule) isApplied(gexp *expression.GomegaExpression, config config.Config) bool {
+	return config.ForeToNot && gexp.GetMatcher().HasNotMatcher()
+}

--- a/testdata/src/a/to_and_not/to_and_not.go
+++ b/testdata/src/a/to_and_not/to_and_not.go
@@ -1,0 +1,38 @@
+package to_and_not
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("test data for the ginkgo-linter", func() {
+	It("Not and To for boolean assertions", func() {
+		Expect(true).To(Not(BeFalse()))       // want `avoid double negative assertion. Consider using .Expect\(true\)\.To\(BeTrue\(\)\). instead`
+		Expect(true).ToNot(Not(BeTrue()))     // want `simplify negation by removing the 'Not' matcher\. Consider using .Expect\(true\)\.To\(BeTrue\(\)\). instead`
+		Expect(true).NotTo(Not(BeTrue()))     // want `simplify negation by removing the 'Not' matcher\. Consider using .Expect\(true\)\.To\(BeTrue\(\)\). instead`
+		Expect(true).ShouldNot(Not(BeTrue())) // want `simplify negation by removing the 'Not' matcher\. Consider using .Expect\(true\)\.Should\(BeTrue\(\)\). instead`
+
+		Eventually(func() bool { return true }).Should(Not(BeFalse()))   // want `avoid double negative assertion\. Consider using .Eventually\(func\(\) bool { return true }\).Should\(BeTrue\(\)\). instead`
+		Eventually(func() bool { return true }).ShouldNot(Not(BeTrue())) // want `simplify negation by removing the 'Not' matcher\. Consider using .Eventually\(func\(\) bool { return true }\)\.Should\(BeTrue\(\)\). instead`
+		Eventually(func() bool { return true }).To(Not(BeFalse()))       // want `avoid double negative assertion\. Consider using .Eventually\(func\(\) bool { return true }\)\.To\(BeTrue\(\)\). instead`
+		Eventually(func() bool { return true }).ToNot(Not(BeTrue()))     // want `simplify negation by removing the 'Not' matcher\. Consider using .Eventually\(func\(\) bool { return true }\)\.To\(BeTrue\(\)\). instead`
+		Eventually(func() bool { return true }).NotTo(Not(BeTrue()))     // want `simplify negation by removing the 'Not' matcher\. Consider using .Eventually\(func\(\) bool { return true }\)\.To\(BeTrue\(\)\). instead`
+	})
+
+	It("Not and To for other matchers", func() {
+		s := []int{1, 2, 3}
+		Expect(s).To(Not(BeEmpty()))                 // want `simplify negation by removing the 'Not' matcher\. Consider using .Expect\(s\)\.ToNot\(BeEmpty\(\)\). instead`
+		Expect(s).ToNot(Not(HaveLen(3)))             // want `simplify negation by removing the 'Not' matcher\. Consider using .Expect\(s\)\.To\(HaveLen\(3\)\). instead`
+		Expect(s).To(Not(Not(HaveLen(3))))           // want `simplify negation by removing the 'Not' matcher\. Consider using .Expect\(s\)\.To\(HaveLen\(3\)\). instead`
+		Expect(s).To(Not(Not(Not(HaveLen(3)))))      // want `simplify negation by removing the 'Not' matcher\. Consider using .Expect\(s\)\.ToNot\(HaveLen\(3\)\). instead`
+		Expect(s).To(Not(Not(Not(Not(HaveLen(3)))))) // want `simplify negation by removing the 'Not' matcher\. Consider using .Expect\(s\)\.To\(HaveLen\(3\)\). instead`
+		Expect(s).NotTo(Not(HaveLen(3)))             // want `simplify negation by removing the 'Not' matcher\. Consider using .Expect\(s\)\.To\(HaveLen\(3\)\). instead`
+		Expect(s).ShouldNot(Not(HaveLen(3)))         // want `simplify negation by removing the 'Not' matcher\. Consider using .Expect\(s\)\.Should\(HaveLen\(3\)\). instead`
+
+		Eventually(func() []int { return s }).Should(Not(HaveLen(3)))    // want `simplify negation by removing the 'Not' matcher\. Consider using .Eventually\(func\(\) \[\]int { return s }\).ShouldNot\(HaveLen\(3\)\). instead`
+		Eventually(func() []int { return s }).ShouldNot(Not(HaveLen(3))) // want `simplify negation by removing the 'Not' matcher\. Consider using .Eventually\(func\(\) \[\]int { return s }\).Should\(HaveLen\(3\)\). instead`
+		Eventually(func() []int { return s }).To(Not(HaveLen(3)))        // want `simplify negation by removing the 'Not' matcher\. Consider using .Eventually\(func\(\) \[\]int { return s }\).ToNot\(HaveLen\(3\)\). instead`
+		Eventually(func() []int { return s }).ToNot(Not(HaveLen(3)))     // want `simplify negation by removing the 'Not' matcher\. Consider using .Eventually\(func\(\) \[\]int { return s }\).To\(HaveLen\(3\)\). instead`
+		Eventually(func() []int { return s }).NotTo(Not(HaveLen(3)))     // want `simplify negation by removing the 'Not' matcher\. Consider using .Eventually\(func\(\) \[\]int { return s }\).To\(HaveLen\(3\)\). instead`
+	})
+})

--- a/testdata/src/a/to_and_not/to_and_not.gomega.go
+++ b/testdata/src/a/to_and_not/to_and_not.gomega.go
@@ -1,0 +1,38 @@
+package to_and_not
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = Describe("test data for the ginkgo-linter", func() {
+	It("Not and To for boolean assertions", func() {
+		gomega.Expect(true).To(gomega.Not(gomega.BeFalse()))       // want `avoid double negative assertion. Consider using .gomega\.Expect\(true\)\.To\(gomega\.BeTrue\(\)\). instead`
+		gomega.Expect(true).ToNot(gomega.Not(gomega.BeTrue()))     // want `simplify negation by removing the 'Not' matcher\. Consider using .gomega\.Expect\(true\)\.To\(gomega\.BeTrue\(\)\). instead`
+		gomega.Expect(true).NotTo(gomega.Not(gomega.BeTrue()))     // want `simplify negation by removing the 'Not' matcher\. Consider using .gomega\.Expect\(true\)\.To\(gomega\.BeTrue\(\)\). instead`
+		gomega.Expect(true).ShouldNot(gomega.Not(gomega.BeTrue())) // want `simplify negation by removing the 'Not' matcher\. Consider using .gomega\.Expect\(true\)\.Should\(gomega\.BeTrue\(\)\). instead`
+
+		gomega.Eventually(func() bool { return true }).Should(gomega.Not(gomega.BeFalse()))   // want `avoid double negative assertion\. Consider using .gomega\.Eventually\(func\(\) bool { return true }\).Should\(gomega\.BeTrue\(\)\). instead`
+		gomega.Eventually(func() bool { return true }).ShouldNot(gomega.Not(gomega.BeTrue())) // want `simplify negation by removing the 'Not' matcher\. Consider using .gomega\.Eventually\(func\(\) bool { return true }\)\.Should\(gomega\.BeTrue\(\)\). instead`
+		gomega.Eventually(func() bool { return true }).To(gomega.Not(gomega.BeFalse()))       // want `avoid double negative assertion\. Consider using .gomega\.Eventually\(func\(\) bool { return true }\)\.To\(gomega\.BeTrue\(\)\). instead`
+		gomega.Eventually(func() bool { return true }).ToNot(gomega.Not(gomega.BeTrue()))     // want `simplify negation by removing the 'Not' matcher\. Consider using .gomega\.Eventually\(func\(\) bool { return true }\)\.To\(gomega\.BeTrue\(\)\). instead`
+		gomega.Eventually(func() bool { return true }).NotTo(gomega.Not(gomega.BeTrue()))     // want `simplify negation by removing the 'Not' matcher\. Consider using .gomega\.Eventually\(func\(\) bool { return true }\)\.To\(gomega\.BeTrue\(\)\). instead`
+	})
+
+	It("Not and To for other matchers", func() {
+		s := []int{1, 2, 3}
+		gomega.Expect(s).To(gomega.Not(gomega.BeEmpty()))                                      // want `simplify negation by removing the 'Not' matcher\. Consider using .gomega\.Expect\(s\)\.ToNot\(gomega\.BeEmpty\(\)\). instead`
+		gomega.Expect(s).ToNot(gomega.Not(gomega.HaveLen(3)))                                  // want `simplify negation by removing the 'Not' matcher\. Consider using .gomega\.Expect\(s\)\.To\(gomega\.HaveLen\(3\)\). instead`
+		gomega.Expect(s).To(gomega.Not(gomega.Not(gomega.HaveLen(3))))                         // want `simplify negation by removing the 'Not' matcher\. Consider using .gomega\.Expect\(s\)\.To\(gomega\.HaveLen\(3\)\). instead`
+		gomega.Expect(s).To(gomega.Not(gomega.Not(gomega.Not(gomega.HaveLen(3)))))             // want `simplify negation by removing the 'Not' matcher\. Consider using .gomega\.Expect\(s\)\.ToNot\(gomega\.HaveLen\(3\)\). instead`
+		gomega.Expect(s).To(gomega.Not(gomega.Not(gomega.Not(gomega.Not(gomega.HaveLen(3)))))) // want `simplify negation by removing the 'Not' matcher\. Consider using .gomega\.Expect\(s\)\.To\(gomega\.HaveLen\(3\)\). instead`
+		gomega.Expect(s).NotTo(gomega.Not(gomega.HaveLen(3)))                                  // want `simplify negation by removing the 'Not' matcher\. Consider using .gomega\.Expect\(s\)\.To\(gomega\.HaveLen\(3\)\). instead`
+		gomega.Expect(s).ShouldNot(gomega.Not(gomega.HaveLen(3)))                              // want `simplify negation by removing the 'Not' matcher\. Consider using .gomega\.Expect\(s\)\.Should\(gomega\.HaveLen\(3\)\). instead`
+
+		gomega.Eventually(func() []int { return s }).Should(gomega.Not(gomega.HaveLen(3)))    // want `simplify negation by removing the 'Not' matcher\. Consider using .gomega\.Eventually\(func\(\) \[\]int { return s }\).ShouldNot\(gomega\.HaveLen\(3\)\). instead`
+		gomega.Eventually(func() []int { return s }).ShouldNot(gomega.Not(gomega.HaveLen(3))) // want `simplify negation by removing the 'Not' matcher\. Consider using .gomega\.Eventually\(func\(\) \[\]int { return s }\).Should\(gomega\.HaveLen\(3\)\). instead`
+		gomega.Eventually(func() []int { return s }).To(gomega.Not(gomega.HaveLen(3)))        // want `simplify negation by removing the 'Not' matcher\. Consider using .gomega\.Eventually\(func\(\) \[\]int { return s }\).ToNot\(gomega\.HaveLen\(3\)\). instead`
+		gomega.Eventually(func() []int { return s }).ToNot(gomega.Not(gomega.HaveLen(3)))     // want `simplify negation by removing the 'Not' matcher\. Consider using .gomega\.Eventually\(func\(\) \[\]int { return s }\).To\(gomega\.HaveLen\(3\)\). instead`
+		gomega.Eventually(func() []int { return s }).NotTo(gomega.Not(gomega.HaveLen(3)))     // want `simplify negation by removing the 'Not' matcher\. Consider using .gomega\.Eventually\(func\(\) \[\]int { return s }\).To\(gomega\.HaveLen\(3\)\). instead`
+	})
+})

--- a/tests/testdata/tonot.txtar
+++ b/tests/testdata/tonot.txtar
@@ -1,0 +1,90 @@
+# run ginkgolinter - no error expected
+exec ginkgolinter tonot
+! stdout .
+! stderr .
+
+# enable forcetonot, expect one error
+! exec ginkgolinter --force-tonot tonot
+! stdout .
+stderr -count=1 'simplify negation by removing the '''Not''' matcher'
+stderr -count=1 'Expect\(false\).ToNot\(BeTrue\(\)\)'
+
+# run with -fix, expect error
+exec ginkgolinter --fix --force-tonot tonot
+! stdout .
+! stderr .
+
+# run again after fix, expect no error
+exec ginkgolinter  --force-tonot tonot
+! stdout .
+! stderr .
+
+-- tonot.go --
+package tonot
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ToNot", func() {
+	It("should enforce ToNot", func() {
+		Expect(false).To(Not(BeTrue()))
+	})
+})
+
+-- go.mod --
+module tonot
+
+go 1.23.0
+
+require (
+	github.com/onsi/ginkgo/v2 v2.23.0
+	github.com/onsi/gomega v1.36.2
+)
+
+require (
+	github.com/go-logr/logr v1.4.2 // indirect
+	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad // indirect
+	golang.org/x/net v0.37.0 // indirect
+	golang.org/x/sys v0.31.0 // indirect
+	golang.org/x/text v0.23.0 // indirect
+	golang.org/x/tools v0.31.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+-- go.sum --
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
+github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
+github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad h1:a6HEuzUHeKH6hwfN/ZoQgRgVIWFJljSWa/zetS2WTvg=
+github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
+github.com/onsi/ginkgo/v2 v2.23.0 h1:FA1xjp8ieYDzlgS5ABTpdUDB7wtngggONc8a7ku2NqQ=
+github.com/onsi/ginkgo/v2 v2.23.0/go.mod h1:zXTP6xIp3U8aVuXN8ENK9IXRaTjFnpVB9mGmaSRvxnM=
+github.com/onsi/gomega v1.36.2 h1:koNYke6TVk6ZmnyHrCXba/T/MoLBXFjeC1PtvYgw0A8=
+github.com/onsi/gomega v1.36.2/go.mod h1:DdwyADRjrc825LhMEkD76cHR5+pUnjhUN8GlHlRPHzY=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+golang.org/x/net v0.37.0 h1:1zLorHbz+LYj7MQlSf1+2tPIIgibq2eL5xkrGk6f+2c=
+golang.org/x/net v0.37.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
+golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
+golang.org/x/tools v0.31.0 h1:0EedkvKDbh+qistFTd0Bcwe/YLh4vHwWEkiI0toFIBU=
+golang.org/x/tools v0.31.0/go.mod h1:naFTU+Cev749tSJRXJlna0T3WxKvb1kWEx15xA4SdmQ=
+google.golang.org/protobuf v1.36.1 h1:yBPeRvTftaleIgM3PZ/WBIZ7XM/eEYAaEyCwvyjq/gk=
+google.golang.org/protobuf v1.36.1/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
enforces that `ToNot` or `ShouldNot` are used instead of `To(Not())` or `Should(Not())`.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Refactoring

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added test case and related test data
- [x] Update the functional test

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran `make goimports`
- [x] I ran [golangci-lint](https://github.com/golangci/golangci-lint)


Fixes #205
